### PR TITLE
fix(FuseAddNorm): fix dtype error for fused_add_norm

### DIFF
--- a/xpu_graph/passes/patterns/targets/mlu/fuse_add_norm.py
+++ b/xpu_graph/passes/patterns/targets/mlu/fuse_add_norm.py
@@ -30,6 +30,9 @@ class FusedNormReplacement(nn.Module):
     ):
         if bias is None:
             bias = torch.zeros_like(weight)
+        dtype = torch.promote_types(input.dtype, residual.dtype)
+        input = input.to(dtype)
+        residual = residual.to(dtype)
         if store_output_before_norm:
             if norm_type == "layer_norm":
                 output, residual = torch_mlu_ops.fused_layer_norm(


### PR DESCRIPTION
fix(FuseAddNorm): fix dtype error for fused_add_norm 
* Bug description: torch.mlu_ops.fused_layer_norm requires input and residual be the same dtype
 * Bugfix: promote dtypes at the entrance of the replacement module