### PR TITLE
    fix(<3.10 unsupport "type | type"): TypeError: unsupported operan…

### DIFF
--- a/xpu_graph/passes/pass_manager.py
+++ b/xpu_graph/passes/pass_manager.py
@@ -42,7 +42,6 @@ class PassManager:
         changed = True
         while changed:
             from torch.fx.passes.shape_prop import ShapeProp
-
             ShapeProp(gm).propagate(*example_inputs)
             changed = False
             for pass_ in self._passes:

--- a/xpu_graph/passes/patterns/structure/fuse_layernorm.py
+++ b/xpu_graph/passes/patterns/structure/fuse_layernorm.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union, Tuple
 
 import torch
 from torch import nn, fx
@@ -26,7 +26,7 @@ from ..utils.check_ops import (
 
 def _is_unaffined_layernorm(
     node: fx.Node,
-) -> tuple[bool, Optional[tuple[fx.Node, Optional[float | int]]]]:
+) -> Tuple[bool, Optional[Tuple[fx.Node, Optional[Union[float, int]]]]]:
     # Matching: y = (x - mean(x)) / sqrt(var(x) + eps)
     # Or:       y = (x - mean(x)) * rsqrt(var(x) + eps)
     matched, node0, node1 = check_div_or_mul_op(node)
@@ -90,7 +90,7 @@ def _is_unaffined_layernorm(
 
 def _is_unbiased_layernorm(
     node: fx.Node,
-) -> tuple[bool, Optional[tuple[fx.Node, Optional[float | int], Optional[fx.Node]]]]:
+) -> Tuple[bool, Optional[Tuple[fx.Node, Optional[Union[float, int]], Optional[fx.Node]]]]:
     res, nodes = _is_unaffined_layernorm(node)
     if res:
         input, eps = nodes
@@ -122,12 +122,12 @@ def _is_unbiased_layernorm(
 
 def _is_layernorm(
     node: fx.Node,
-) -> tuple[
+) -> Tuple[
     bool,
     Optional[
-        tuple[
+        Tuple[
             fx.Node,
-            Optional[float | int],
+            Optional[Union[float, int]],
             Optional[fx.Node],
             Optional[fx.Node],
             list[fx.Node],

--- a/xpu_graph/passes/patterns/structure/fuse_slice.py
+++ b/xpu_graph/passes/patterns/structure/fuse_slice.py
@@ -1,6 +1,6 @@
 import torch
 from torch import nn, fx
-import torch_mlu
+# import torch_mlu
 from xpu_graph.passes.patterns.pattern import Pattern, PatternGroup
 from typing import Callable
 from ..utils.check_ops import (

--- a/xpu_graph/passes/patterns/utils/check_ops.py
+++ b/xpu_graph/passes/patterns/utils/check_ops.py
@@ -1,7 +1,7 @@
 import torch
 import operator
 from torch import nn, fx
-
+from typing import Union, Tuple
 
 def _is_valid_node(node: fx.Node) -> bool:
     return isinstance(node, fx.Node) and node.op == "call_function"
@@ -96,7 +96,7 @@ def get_dtype(node: fx.Node):
 
 def check_sub_or_add_op(
     node: fx.Node,
-) -> tuple[bool, fx.Node | None, tuple[fx.Node | None, bool] | None]:
+) -> Tuple[bool, Union[fx.Node, None], Union[Tuple[Union[fx.Node, None], bool], None]]:
     if not _is_valid_node(node):
         return False, None, ()
 
@@ -114,7 +114,7 @@ def check_sub_or_add_op(
 
 def check_div_or_mul_op(
     node: fx.Node,
-) -> tuple[bool, fx.Node | None, tuple[fx.Node | None, bool] | None]:
+) -> Tuple[bool, Union[fx.Node, None], Union[Tuple[Union[fx.Node, None], bool], None]]:
     if not _is_valid_node(node):
         return False, None, ()
 
@@ -130,7 +130,7 @@ def check_div_or_mul_op(
     return True, node0, (node1, is_div)
 
 
-def check_bmm_op(node: fx.Node) -> tuple[bool, fx.Node | None, fx.Node | None]:
+def check_bmm_op(node: fx.Node) -> Tuple[bool, Union[fx.Node, None], Union[fx.Node, None]]:
     if not check_op(node, torch.ops.aten.bmm.default):
         return False, None, None
 
@@ -139,7 +139,7 @@ def check_bmm_op(node: fx.Node) -> tuple[bool, fx.Node | None, fx.Node | None]:
     return True, arg1, arg2
 
 
-def check_mm_op(node: fx.Node) -> tuple[bool, fx.Node | None, fx.Node | None]:
+def check_mm_op(node: fx.Node) -> Tuple[bool, Union[fx.Node, None], Union[fx.Node, None]]:
     if not check_op(node, torch.ops.aten.mm.default):
         return False, None, None
 
@@ -197,7 +197,7 @@ def check_t_op(node: fx.Node) -> bool:
 
 def check_act_op(
     node: fx.Node,
-) -> tuple[bool, fx.Node | None, tuple[fx.Node | None, bool] | None]:
+) -> Tuple[bool, Union[fx.Node, None], Union[Tuple[Union[fx.Node, None], bool], None]]:
     if not _is_valid_node(node):
         return False, None
     if node.target == torch.ops.aten.silu.default:
@@ -251,7 +251,7 @@ def check_norm_op(node: fx.node):
 
 def check_addmm_op(
     node: fx.Node,
-) -> tuple[bool, fx.Node | None, fx.Node | None, fx.Node | None]:
+) -> Tuple[bool, Union[fx.Node, None], Union[fx.Node, None], Union[fx.Node, None]]:
     if not check_op(node, torch.ops.aten.addmm.default):
         return False, None, None, None
     arg1 = get_input_node(node, 0)


### PR DESCRIPTION
…d type(s) for |: 'type' and 'type'

    * Bug description: 3.10+ fully support, 3.9 support tuple[...] and use Union to replace |, <3.8 impl with typing.Tuple and Union