### PR TITLE
fix(RemoveLNCast): enable RemoveLayerNormCast along with FusedLayerNorm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/neuware/lib64
           pip install --root-user-action=ignore -e .
           export MLU_VISIBLE_DEVICES=7
-          pytest tests/mlu/test_*
+          pytest --ignore=tests/xpu_ops tests

--- a/tests/common/test_fuse_layernorm.py
+++ b/tests/common/test_fuse_layernorm.py
@@ -1,0 +1,85 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from xpu_graph.config import OptLevel
+import xpu_graph
+from xpu_graph.test_utils import is_similar, maybe_similar
+import pytest
+
+device = "cpu"
+data_type = torch.float32
+aten = torch.ops.aten
+
+
+def fn0(inputs, weight, bias):
+    mean = torch.mean(inputs, dim=-1, keepdim=True)
+    variance = torch.var(
+        inputs, dim=-1, keepdim=True, unbiased=False
+    )  # unbiased=False == tf.nn.moments
+    normalized = (inputs - mean) / ((variance + 1e-6) ** (0.5))
+    outputs = weight * normalized + bias
+    return outputs
+
+
+def fn1(inputs, weight, bias):
+    mean = torch.mean(inputs, dim=-1, keepdim=True)
+    variance = torch.var(
+        inputs, dim=-1, keepdim=True, unbiased=False
+    )  # unbiased=False == tf.nn.moments
+    normalized = (inputs - mean) * torch.rsqrt(1e-6 + variance)
+    outputs = bias + normalized
+    return outputs
+
+
+def fn2(inputs, weight, bias):
+    mean = torch.mean(inputs, dim=-1, keepdim=True)
+    variance = torch.var(inputs, dim=-1, keepdim=True, correction=0)
+    normalized = (inputs - mean) / torch.sqrt(variance + 1e-5)
+    return normalized
+
+
+def fn3(inputs, weight, bias):
+    mean = torch.mean(inputs, dim=-1, keepdim=True)
+    variance = torch.var(inputs, dim=-1, keepdim=True, correction=0)
+    normalized = (inputs - mean) * ((variance + 1e-5) ** (-0.5))
+    return weight * normalized
+
+
+def layernorm_test(xpu_graph, func):
+    inputs = torch.randn((8, 1024), device=device, dtype=data_type)
+    weight = torch.randn((1024), device=device, dtype=data_type)
+    bias = None
+    compiled = torch.compile(func, backend=xpu_graph, dynamic=False)
+    if func == fn0 or func == fn1:
+        bias = torch.randn((1024,), device=device, dtype=data_type)
+        norm = compiled(inputs, weight, bias)
+        norm1 = func(inputs, weight, bias)
+        assert is_similar(norm1, norm)
+    if func == fn2 or func == fn3:
+        norm = compiled(inputs, weight, bias)
+        norm1 = func(inputs, weight, bias)
+        assert is_similar(norm1, norm)
+
+
+class TestLayerNorm:
+    def setup_class(self):
+        config = xpu_graph.XpuGraphConfig(opt_level=OptLevel.level2, freeze=False)
+        self.xpu_graph_backend = xpu_graph.XpuGraph(config)
+
+    @pytest.mark.parametrize(
+        "pattern_func",
+        [fn0, fn1],
+    )
+    def test_layernrom_patterns(self, pattern_func):
+        layernorm_test(self.xpu_graph_backend, pattern_func)
+
+
+if __name__ == "__main__":
+    config = xpu_graph.XpuGraphConfig(
+        opt_level=OptLevel.level2, freeze=False, debug=True
+    )
+    xpu_graph_backend = xpu_graph.XpuGraph(config)
+    layernorm_test(xpu_graph_backend, fn0)
+    layernorm_test(xpu_graph_backend, fn1)
+    layernorm_test(xpu_graph_backend, fn2)
+    layernorm_test(xpu_graph_backend, fn3)

--- a/tests/common/test_fuse_layernorm.py
+++ b/tests/common/test_fuse_layernorm.py
@@ -68,7 +68,7 @@ class TestLayerNorm:
 
     @pytest.mark.parametrize(
         "pattern_func",
-        [fn0, fn1],
+        [fn0, fn1, fn2, fn3],
     )
     def test_layernrom_patterns(self, pattern_func):
         layernorm_test(self.xpu_graph_backend, pattern_func)

--- a/tests/common/test_register_pattern.py
+++ b/tests/common/test_register_pattern.py
@@ -2,10 +2,6 @@ import torch
 from xpu_graph.compiler import XpuGraph
 import torch.fx as fx
 
-import xpu_ops
-
-xpu_ops.load_xpu_ops_npu()
-
 
 def test_register_pattern():
     def _add(x, y):
@@ -29,3 +25,7 @@ def test_register_pattern():
     from xpu_graph.test_utils import is_similar
 
     assert is_similar(res, a - b)
+
+
+if __name__ == "__main__":
+    test_register_pattern()

--- a/tests/common/test_remove_layernorm_cast.py
+++ b/tests/common/test_remove_layernorm_cast.py
@@ -1,0 +1,56 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from xpu_graph.config import OptLevel
+import xpu_graph
+from xpu_graph.test_utils import is_similar
+import pytest
+
+device = "cpu"
+data_type = torch.float16
+aten = torch.ops.aten
+
+
+def fn0(inputs, weight, bias):
+    orig_dtype = inputs.dtype
+    inputs = inputs.float()
+    mean = torch.mean(inputs, dim=-1, keepdim=True)
+    variance = torch.var(
+        inputs, dim=-1, keepdim=True, unbiased=False
+    )  # unbiased=False == tf.nn.moments
+    normalized = (inputs - mean) / ((variance + 1e-6) ** (0.5))
+    outputs = weight * normalized + bias
+    outputs = outputs.to(dtype=orig_dtype)
+    return outputs
+
+def layernorm_test(xpu_graph, func):
+    inputs = torch.randn((8, 1024), device=device, dtype=data_type)
+    weight = torch.randn((1024), device=device, dtype=data_type)
+    bias = None
+    compiled = torch.compile(func, backend=xpu_graph, dynamic=False)
+    if func == fn0:
+        bias = torch.randn((1024,), device=device, dtype=data_type)
+        norm = compiled(inputs, weight, bias)
+        norm1 = func(inputs, weight, bias)
+        assert is_similar(norm1, norm)
+
+
+class TestLayerNorm:
+    def setup_class(self):
+        config = xpu_graph.XpuGraphConfig(opt_level=OptLevel.level2, freeze=True)
+        self.xpu_graph_backend = xpu_graph.XpuGraph(config)
+
+    @pytest.mark.parametrize(
+        "pattern_func",
+        [fn0],
+    )
+    def test_layernrom_patterns(self, pattern_func):
+        layernorm_test(self.xpu_graph_backend, pattern_func)
+
+
+if __name__ == "__main__":
+    config = xpu_graph.XpuGraphConfig(
+        opt_level=OptLevel.level2, freeze=True, debug=True
+    )
+    xpu_graph_backend = xpu_graph.XpuGraph(config)
+    layernorm_test(xpu_graph_backend, fn0)

--- a/tests/mlu/test_ffn.py
+++ b/tests/mlu/test_ffn.py
@@ -136,4 +136,8 @@ class TestFFN:
 
 
 if __name__ == "__main__":
-    pytest.main()
+    xpu_graph_backend = xpu_graph.mlu_compiler()
+    ffn_test(xpu_graph_backend, fn0)
+    ffn_test(xpu_graph_backend, fn1)
+    ffn_test(xpu_graph_backend, fn2)
+    ffn_test(xpu_graph_backend, fn3)

--- a/tests/mlu/test_fuse_layernorm.py
+++ b/tests/mlu/test_fuse_layernorm.py
@@ -29,41 +29,7 @@ def fn1(inputs, residual, weight, bias):
     )
     return output, inputs_
 
-
-def fn2(inputs, weight, bias):
-    mean = torch.mean(inputs, dim=-1, keepdim=True)
-    variance = torch.var(
-        inputs, dim=-1, keepdim=True, unbiased=False
-    )  # unbiased=False == tf.nn.moments
-    normalized = (inputs - mean) / ((variance + 1e-6) ** (0.5))
-    outputs = weight * normalized + bias
-    return outputs
-
-
-def fn3(inputs, weight, bias):
-    mean = torch.mean(inputs, dim=-1, keepdim=True)
-    variance = torch.var(
-        inputs, dim=-1, keepdim=True, unbiased=False
-    )  # unbiased=False == tf.nn.moments
-    normalized = (inputs - mean) * torch.rsqrt(1e-6 + variance)
-    outputs = bias + normalized
-    return outputs
-
-
-def fn4(inputs, weight, bias):
-    mean = torch.mean(inputs, dim=-1, keepdim=True)
-    variance = torch.var(inputs, dim=-1, keepdim=True, correction=0)
-    normalized = (inputs - mean) / torch.sqrt(variance + 1e-5)
-    return normalized
-
-
-def fn5(inputs, weight, bias):
-    mean = torch.mean(inputs, dim=-1, keepdim=True)
-    variance = torch.var(inputs, dim=-1, keepdim=True, correction=0)
-    normalized = (inputs - mean) * ((variance + 1e-5) ** (-0.5))
-    return weight * normalized
-
-def fn6(inputs, residual, weight, bias):
+def fn2(inputs, residual, weight, bias):
     residual = residual.to(torch.float32)
     weight = weight.to(torch.float32)
     if bias is not None:
@@ -80,7 +46,7 @@ def layernorm_test(xpu_graph, func):
     weight = torch.randn((1024), device=device, dtype=data_type)
     bias = None
     compiled = torch.compile(func, backend=xpu_graph, dynamic=False)
-    if func == fn0 or func == fn6:
+    if func == fn0 or func == fn2:
         norm = compiled(inputs, residual, weight, bias)
         norm1 = func(inputs, residual, weight, bias)
         assert is_similar(norm1, norm)
@@ -89,15 +55,6 @@ def layernorm_test(xpu_graph, func):
         norm1, res1 = func(inputs, residual, weight, bias)
         assert is_similar(norm1, norm)
         assert is_similar(res1, res)
-    if func == fn2 or func == fn3:
-        bias = torch.randn((1024,), device=device, dtype=data_type)
-        norm = compiled(inputs, weight, bias)
-        norm1 = func(inputs, weight, bias)
-        assert is_similar(norm1, norm)
-    if func == fn4 or func == fn5:
-        norm = compiled(inputs, weight, bias)
-        norm1 = func(inputs, weight, bias)
-        assert is_similar(norm1, norm)
 
 
 class TestLayerNorm:
@@ -108,7 +65,7 @@ class TestLayerNorm:
 
     @pytest.mark.parametrize(
         "pattern_func",
-        [fn0, fn2, fn6],
+        [fn0, fn2],
     )
     def test_layernrom_patterns(self, pattern_func):
         layernorm_test(self.xpu_graph_backend, pattern_func)
@@ -119,7 +76,3 @@ if __name__ == "__main__":
     layernorm_test(xpu_graph_backend, fn0)
     layernorm_test(xpu_graph_backend, fn1)
     layernorm_test(xpu_graph_backend, fn2)
-    layernorm_test(xpu_graph_backend, fn3)
-    layernorm_test(xpu_graph_backend, fn4)
-    layernorm_test(xpu_graph_backend, fn5)
-    layernorm_test(xpu_graph_backend, fn6)

--- a/tests/mlu/test_fuse_sum_cat.py
+++ b/tests/mlu/test_fuse_sum_cat.py
@@ -101,4 +101,12 @@ class TestSumCat:
 
 
 if __name__ == "__main__":
-    pytest.main()
+    config = xpu_graph.config.XpuGraphConfig()
+    config.target = xpu_graph.config.Target.mlu
+    xpu_graph_backend = xpu_graph.compiler.XpuGraph(config)
+    sumcat_test(xpu_graph_backend, fn0)
+    sumcat_test(xpu_graph_backend, fn1)
+    sumcat_test(xpu_graph_backend, fn2)
+    sumcat_test(xpu_graph_backend, fn3)
+    sumcat_test(xpu_graph_backend, fn4)
+    sumcat_test(xpu_graph_backend, fn5)

--- a/tests/mlu/test_linear_attention.py
+++ b/tests/mlu/test_linear_attention.py
@@ -75,6 +75,6 @@ if __name__ == "__main__":
     config = xpu_graph.config.XpuGraphConfig()
     config.target = xpu_graph.config.Target.mlu
     config.opt_level = OptLevel.level2
-    xpu_graph = xpu_graph.compiler.XpuGraph(config)
-    linear_attention_test(xpu_graph, fn0)
-    linear_attention_test(xpu_graph, fn1)
+    xpu_graph_backend = xpu_graph.compiler.XpuGraph(config)
+    linear_attention_test(xpu_graph_backend, fn0)
+    linear_attention_test(xpu_graph_backend, fn1)

--- a/tests/mlu/test_slice_sum_cat.py
+++ b/tests/mlu/test_slice_sum_cat.py
@@ -100,3 +100,7 @@ class TestSliceSumCat:
 if __name__ == "__main__":
     xpu_graph_backend = xpu_graph.mlu_compiler(opt_level=OptLevel.level2)
     sumcat_test(xpu_graph_backend, fn0)
+    sumcat_test(xpu_graph_backend, fn1)
+    sumcat_test(xpu_graph_backend, fn2)
+    sumcat_test(xpu_graph_backend, fn3)
+    sumcat_test(xpu_graph_backend, fn4)

--- a/xpu_graph/fx_utils.py
+++ b/xpu_graph/fx_utils.py
@@ -1,6 +1,13 @@
 import torch
 import torch.utils._pytree as pytree
 
+from torch.fx import map_arg
+from torch.fx.experimental.proxy_tensor import make_fx, wrapper_and_args_for_make_fx
+from torch.fx.proxy import Proxy, GraphAppendingTracer
+
+from typing import Union, Callable
+
+
 def unlift_gm(mod, gm, graph_signature):
     from torch.export.unflatten import _assign_attr, _AttrKind
 
@@ -54,3 +61,32 @@ def unlift_gm(mod, gm, graph_signature):
         {},
     )
     return unlifted_gm
+
+
+def trace_and_inline(
+    graph_module: torch.fx.GraphModule,
+    mod_or_func: Union[str, Callable],
+):
+    """Tracing a submodule or a function and inline the traced sub_graph"""
+
+    if isinstance(mod_or_func, str):
+        callable = graph_module.get_submodule(mod_or_func)
+    else:
+        callable = mod_or_func
+
+    def inliner(*args, **kwargs):
+        wrapped, arglist = wrapper_and_args_for_make_fx(callable, args, kwargs)
+
+        # use the original (fake) tensor to avoid dynamic-control-flow issues
+        f_arglist = list(map_arg(arglist, lambda arg: arg.meta["val"]))
+        traced = make_fx(
+            wrapped, record_module_stack=True, tracing_mode="fake"
+        )(f_arglist)
+        traced.recompile()
+
+        tracer = GraphAppendingTracer(graph_module.graph)
+        p_arglist = list(map_arg(arglist, lambda arg: Proxy(arg, tracer)))
+        rets = traced(p_arglist)
+        return rets.node
+
+    return inliner

--- a/xpu_graph/passes/patterns/pattern_manager.py
+++ b/xpu_graph/passes/patterns/pattern_manager.py
@@ -7,6 +7,7 @@ from xpu_graph.passes.optimizer import Optimizer
 from xpu_graph.config import XpuGraphConfig, Target
 from .pattern import Pattern, PatternGroup
 
+
 class PatternManager(Optimizer):
     def __init__(self, config: XpuGraphConfig):
         super().__init__()
@@ -18,19 +19,23 @@ class PatternManager(Optimizer):
         }
 
         from .common import get_all_patterns as get_common_patterns
+
         for group, patterns in get_common_patterns(config).items():
             self._patterns[group] += patterns
 
         from .structure import get_all_patterns as get_structure_patterns
+
         for group, patterns in get_structure_patterns(config).items():
             self._patterns[group] += patterns
 
         if config.use_xpu_ops:
             from .xpu_ops import get_all_patterns as get_xpu_ops_patterns
+
             for group, patterns in get_xpu_ops_patterns(config).items():
                 self._patterns[group] += patterns
 
         from .targets import get_all_patterns as get_target_patterns
+
         for group, patterns in get_target_patterns(config).items():
             self._patterns[group] += patterns
 
@@ -44,27 +49,27 @@ class PatternManager(Optimizer):
 
         return changed
 
+    @overload
+    def register_pattern(self, pattern: Pattern): ...
 
     @overload
-    def register_pattern(self, pattern: Pattern):
-        ...
-
-    @overload
-    def register_pattern(self, matcher: Callable, replacement: Callable):
-        ...
+    def register_pattern(self, matcher: Callable, replacement: Callable): ...
 
     def register_pattern(self, *args):
         if len(args) == 1:
-            self._patterns.append(args[0]())
+            pat = args[0]
+            self._patterns[pat._pattern_group].append(pat())
         elif len(args) == 2:
+
             class _Pattern(Pattern):
                 def __init__(self):
                     super().__init__()
 
                 def __call__(self, gm: fx.GraphModule) -> bool:
                     from torch.fx import subgraph_rewriter
+
                     match = subgraph_rewriter.replace_pattern(gm, args[0], args[1])
 
                     return len(match)
 
-            self._patterns.append(_Pattern())
+            self._patterns[_Pattern._pattern_group].append(_Pattern())

--- a/xpu_graph/passes/patterns/targets/mlu/structure_replacements.py
+++ b/xpu_graph/passes/patterns/targets/mlu/structure_replacements.py
@@ -19,13 +19,6 @@ class RMSNormModule(torch.nn.Module):
         )
 
 
-class LayerNormModule(torch.nn.Module):
-    def forward(self, input, weight, bias, epsilon):
-        return torch.nn.functional.layer_norm(
-            input, input.shape[-1:], weight, bias, epsilon
-        )
-
-
 class FuseSliceModule(torch.nn.Module):
     def forward(self, input_tensor, slices_index, slice_len):
         if len(input_tensor.shape) != 2:
@@ -69,7 +62,6 @@ class FuseSliceCatSameInputModule(torch.nn.Module):
 def get_structure_replacements():
     return {
         "FusedRMSNorm": RMSNormModule,
-        "FusedLayerNorm": LayerNormModule,
         "FusedSlice": FuseSliceModule,
         "FusedCatSlice": FuseSliceCatSameInputModule,
         "FusedMultipleSliceCat": FuseSliceCatSameInputModule,

--- a/xpu_graph/test_utils.py
+++ b/xpu_graph/test_utils.py
@@ -12,6 +12,12 @@ def is_similar(result, expected, rtol=0.01, atol=0.01):
     )
 
 
+def maybe_similar(result, expected, rtol=0.01, atol=0.01):
+    if result is None or expected is None:
+        return result is None and expected is None
+    return is_similar(result, expected, rtol, atol)
+
+
 def assertTensorsEqual(
     a,
     b,
@@ -84,6 +90,7 @@ def assertTensorsEqual(
             max_err = diff.max()
             tc.assertLessEqual(max_err, prec, message)
 
+
 class need_xpu_graph_logs:
     def __init__(self):
         self.original_propagate = logger.propagate
@@ -98,6 +105,7 @@ class need_xpu_graph_logs:
         logger.propagate = self.original_propagate
         logger.setLevel(self.original_level)
 
+
 class skip_xpu_graph_cache:
     def __init__(self, xpu_graph_backend: XpuGraph):
         self.backend = xpu_graph_backend
@@ -107,7 +115,6 @@ class skip_xpu_graph_cache:
         # Use base cache to skip save/load
         self.backend._cache = XpuGraphCache()
         return self
-    
-    
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.backend._cache = self.cache


### PR DESCRIPTION
* Bugfix: allow FusedLayerNorm to be applied for all targets
* Add: trace_and_inline method in fx_utils.py, trace (external) function and inline the generated subgraph
* Fix: inline fused layernorm immediately after replaced