### PR TITLE
fix(FxGraph): refactor Fx Graph unpickler

### DIFF
--- a/xpu_graph/__init__.py
+++ b/xpu_graph/__init__.py
@@ -20,7 +20,7 @@ def mlu_compiler(
     freeze: bool = True,
     opt_level: OptLevel = OptLevel.level1,
     constant_folding: bool = True,
-    cache: Optional[XpuGraphCache] = no_cache(),
+    cache: Optional[XpuGraphCache] = None,
     debug: bool = False,
     vendor_compiler_config: Dict[str, Any] = {"mode": "reduce-overhead"},
 ) -> XpuGraph:

--- a/xpu_graph/cache.py
+++ b/xpu_graph/cache.py
@@ -1,18 +1,21 @@
 import os
 import hashlib
-import pickle
+import dill
 from os import PathLike
+
 import torch
 from torch._dynamo.convert_frame import compile_lock
 from torch.utils._python_dispatch import _disable_current_modes
+from torch.fx import GraphModule, Graph, Node, map_arg
+
 from .config import XpuGraphConfig
 from .utils import logger
 from .fx_utils import FxStage
 
-""" A base cache class does not store any thing"""
-
 
 class XpuGraphCache:
+    """A base cache class does not store any thing"""
+
     def cache_key(
         self,
         gm: torch.fx.GraphModule,
@@ -55,20 +58,17 @@ class XpuGraphLocalCache(XpuGraphCache):
     ) -> torch.fx.GraphModule:
         artifact_path = self._graph_path(key)
         logger.info(f"Save cache in location: {artifact_path}")
-        with compile_lock, _disable_current_modes():
-            with open(artifact_path, "wb+") as f:
-                pickle.dump(value, f)
-            with open(artifact_path, "rb") as f:
-                cached_graph = pickle.load(f)
+
+        serialize_gm(value, artifact_path)
+        cached_graph = deserialize_gm(artifact_path)
+
         return cached_graph
 
     def load_gm(self, key):
         artifact_path = self._graph_path(key)
         if os.path.isfile(artifact_path):
-            with compile_lock, _disable_current_modes():
-                logger.info(f"Use cache in location: {artifact_path}")
-                with open(artifact_path, "rb") as f:
-                    cached_graph = pickle.load(f)
+            logger.info(f"Use cache in location: {artifact_path}")
+            cached_graph = deserialize_gm(artifact_path)
             return cached_graph
         else:
             return None
@@ -95,3 +95,99 @@ def default_cache():
         cache_path = tempfile.mkdtemp(prefix="xpu_graph_")
         logger.debug(f"Use {cache_path} as default local cache")
     return XpuGraphLocalCache(cache_path)
+
+
+class _GraphModuleData:
+    def __init__(self, gm: GraphModule):
+        if len(gm._modules) > 0:
+            raise NotImplemented("Only fully-inlined graph module is supported")
+        self.gm_dict = gm.__dict__.copy()
+        del self.gm_dict["_graph"]
+        self.graph = _GraphData(gm.graph)
+
+    def unpickle(self) -> GraphModule:
+        gm = GraphModule.__new__(GraphModule)
+        gm.__dict__ = self.gm_dict
+        gm.graph = self.graph.unpickle(gm)
+        gm.recompile()
+        return gm
+
+
+class _GraphData:
+    def __init__(self, graph: Graph):
+        self.nodes = [_NodeData(node) for node in graph.nodes]
+        self.tracer_cls = graph._tracer_cls
+        self.tracer_extras = graph._tracer_extras
+
+    def unpickle(self, root_mod: GraphModule) -> Graph:
+        graph = Graph(root_mod, self.tracer_cls, self.tracer_extras)
+        node_dict = {}
+        for node in self.nodes:
+            n = node.unpickle(graph, node_dict)
+            node_dict[n.name] = n
+        return graph
+
+
+class _NodeData:
+    def __init__(self, node: Node):
+        self.name = node.name
+        self.type = node.type
+        self.op = node.op
+        self.target = node._pretty_print_target(node.target)
+
+        self.args = tuple(map_arg(node.args, lambda n: _ArgWrapper(n)))
+        self.kwargs = dict(map_arg(node.kwargs, lambda n: _ArgWrapper(n)))
+
+    def unpickle(self, graph: Graph, node_dict):
+        def _unwrap(arg):
+            if isinstance(arg, _ArgWrapper):
+                return node_dict[arg.name]
+            else:
+                return arg
+
+        from torch.fx.node import map_aggregate
+
+        args = map_aggregate(self.args, _unwrap)
+        kwargs = map_aggregate(self.kwargs, _unwrap)
+        if self.op == "call_function":
+            target = _get_target_function(self.target)
+        else:
+            target = self.target
+        return graph.create_node(self.op, target, args, kwargs, self.name, self.type)
+
+
+def _get_target_function(fn_name: str):
+    fqn_list = fn_name.split(".")
+    import torch
+    import operator
+    import builtins
+
+    supported_mods = {"torch": torch, "operator": operator, "builtins": builtins}
+    try:
+        target = supported_mods[fqn_list[0]]
+        for attr in fqn_list[1:]:
+            target = getattr(target, attr)
+        assert callable(target)
+    except:
+        raise NotImplementedError(f"Unsupported call_function: {fn_name}")
+    return target
+
+
+class _ArgWrapper:
+    def __init__(self, node: Node):
+        self.name = node.name
+
+
+def serialize_gm(gm: GraphModule, path):
+    with compile_lock, _disable_current_modes():
+        gm_data = _GraphModuleData(gm)
+        with open(path, "wb+") as f:
+            dill.dump(gm_data, f)
+
+
+def deserialize_gm(path):
+    with compile_lock, _disable_current_modes():
+        with open(path, "rb") as f:
+            gm_data = dill.load(f)
+            gm = gm_data.unpickle()
+    return gm

--- a/xpu_graph/compiler.py
+++ b/xpu_graph/compiler.py
@@ -5,6 +5,7 @@ import torch
 from torch._dynamo.backends.common import aot_autograd
 from torch._functorch.aot_autograd import aot_export_module
 from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.fx.experimental.proxy_tensor import make_fx
 
 from .passes.pass_manager import PassManager
 from .passes.patterns.pattern import Pattern
@@ -104,6 +105,14 @@ class XpuGraph:
                     xpu_compiled = self._cache.load_gm(hashkey)
                     if xpu_compiled is None:
                         xpu_compiled = self._pass_manager(gm, fake_inputs, stage)
+                        # Note: Currently, we only inline modules with a E2E make_fx, just for serialize / desrialize
+                        pre_dispatch = stage == FxStage.pregrad
+                        xpu_compiled = make_fx(
+                            xpu_compiled,
+                            tracing_mode="fake",
+                            pre_dispatch=pre_dispatch,
+                            record_module_stack=True,
+                        )(*fake_inputs)
                         xpu_compiled = self._cache.save_gm(hashkey, xpu_compiled)
                 else:
                     xpu_compiled = self._pass_manager(gm, fake_inputs, stage)
@@ -133,8 +142,6 @@ class XpuGraph:
         if self._config.is_training:
             logger.debug(f"before dispatch: graph like:\n {dynamo_gm.graph}")
             logger.info("dispatch graph start...")
-            from torch.fx.experimental.proxy_tensor import make_fx
-
             dispatched_gm = make_fx(
                 dynamo_gm,
                 tracing_mode="fake",

--- a/xpu_graph/passes/pass_manager.py
+++ b/xpu_graph/passes/pass_manager.py
@@ -47,16 +47,6 @@ class PassManager:
                 changed = changed or pass_(gm)
 
         gm.recompile()
-
-        if self.config.enable_cache:
-            # Note: Currently, we only inline modules with a E2E make_fx, just for serialize / desrialize
-            from torch.fx.experimental.proxy_tensor import make_fx
-
-            pre_dispatch = stage == FxStage.pregrad
-            gm = make_fx(gm, pre_dispatch=pre_dispatch, record_module_stack=True)(
-                *example_inputs
-            )
-
         return gm
 
     def get_pattern_manager(self):


### PR DESCRIPTION
* Bug: Vanila-deserialize cached FxGraph makes a mess
* Add: Pickle/Unpickler (simplified ver.) for GraphModule
* Fixed: Support model training mode with xpu_graph cache