### PR TITLE
fix(Cache): alter TRITON_CACHE_DIR for non-inductor kernels as well

### DIFF
--- a/tests/common/test_change_tensor_like.py
+++ b/tests/common/test_change_tensor_like.py
@@ -8,9 +8,11 @@ def fn0(a):
     output = torch.ones_like(a)
     return output
 
+
 def fn1(a):
     output = torch.zeros_like(a)
     return output
+
 
 def fn2(a):
     output = torch.ones_like(a)
@@ -18,19 +20,21 @@ def fn2(a):
 
 
 def inner_fn(zeros, ones):
-        zeros = torch.zeros_like(zeros)
-        ones = torch.ones_like(ones)
-        output = torch.concat([zeros, ones], dim=0)
-        return output
-    
+    zeros = torch.zeros_like(zeros)
+    ones = torch.ones_like(ones)
+    output = torch.concat([zeros, ones], dim=0)
+    return output
+
+
 def fn3(a):
     b = torch.sum(a, dim=1)
     outputs = []
     for i in range(10):
-        output = inner_fn(a[b>=i], a[b<i])
+        output = inner_fn(a[b >= i], a[b < i])
         outputs.append(output)
     output = torch.stack(outputs, dim=0)
     return output
+
 
 def tensorlike_test(xpu_graph, func):
     compiled = torch.compile(func, backend=xpu_graph, dynamic=None)
@@ -59,7 +63,7 @@ class TestTensorLike:
         with need_xpu_graph_logs(), skip_xpu_graph_cache(self.xpu_graph):
             tensorlike_test(self.xpu_graph, pattern_func)
         if pattern_func not in [fn3]:
-            assert "Pattern.ChangeTensorLike changed graph" in caplog.text 
+            assert "Pattern.ChangeTensorLike changed graph" in caplog.text
 
 
 if __name__ == "__main__":

--- a/tests/mlu/test_ddp_matmul.py
+++ b/tests/mlu/test_ddp_matmul.py
@@ -1,11 +1,12 @@
 import pytest
 from tests.mlu.test_train_utils import *
+import os
 
 
-def train(rank, world_size, do_compile, return_queue):
+def train(rank, world_size, do_compile, return_queue, model_path):
     train_setup(rank, world_size)
     model = MatMulModel(10)
-    model.load_state_dict(torch.load("model.pth"))
+    model.load_state_dict(torch.load(model_path))
     if do_compile:
         xpu_graph_backend = xpu_graph.mlu_compiler(
             is_training=True, freeze=False, opt_level=OptLevel.level2
@@ -40,18 +41,18 @@ def train(rank, world_size, do_compile, return_queue):
     cleanup()
 
 
-def ddp_test(fn):
+def ddp_test(ModCls, model_path="ddp_model.pth"):
     mp.set_start_method("spawn", force=True)
     world_size = torch.mlu.device_count()
     return_queue1 = mp.Queue()
     return_queue2 = mp.Queue()
-    model = fn()
-    torch.save(model.state_dict(), "model.pth")
+    model = ModCls()
+    torch.save(model.state_dict(), model_path)
 
     do_compile = 0
     torch.multiprocessing.spawn(
         train,
-        args=(world_size, do_compile, return_queue1),
+        args=(world_size, do_compile, return_queue1, model_path),
         nprocs=world_size,
         join=True,
     )
@@ -63,7 +64,7 @@ def ddp_test(fn):
     do_compile = 1
     torch.multiprocessing.spawn(
         train,
-        args=(world_size, do_compile, return_queue2),
+        args=(world_size, do_compile, return_queue2, model_path),
         nprocs=world_size,
         join=True,
     )
@@ -84,8 +85,8 @@ class TestDDP:
             MatMulModel,
         ],
     )
-    def test_rmsnorm_patterns(self, pattern_func):
-        ddp_test(pattern_func)
+    def test_rmsnorm_patterns(self, tmp_path, pattern_func):
+        ddp_test(pattern_func, tmp_path / "ddp_model.pth")
 
 
 if __name__ == "__main__":

--- a/tests/mlu/test_slice_sum_cat.py
+++ b/tests/mlu/test_slice_sum_cat.py
@@ -100,7 +100,9 @@ class TestSliceSumCat:
 
 
 if __name__ == "__main__":
-    xpu_graph_backend = xpu_graph.mlu_compiler(opt_level=OptLevel.level2)
+    xpu_graph_backend = xpu_graph.mlu_compiler(
+        is_training=False, opt_level=OptLevel.level2
+    )
     sumcat_test(xpu_graph_backend, fn0)
     sumcat_test(xpu_graph_backend, fn1)
     sumcat_test(xpu_graph_backend, fn2)

--- a/xpu_graph/cache.py
+++ b/xpu_graph/cache.py
@@ -37,7 +37,12 @@ class XpuGraphCache:
 
     def delete_gm(self, key):
         return None
-
+    
+    def _set_cache_ctx(self):
+        return None
+        
+    def _restore_cache_ctx(self, orig_ctx):
+        pass
 
 class XpuGraphLocalCache(XpuGraphCache):
     def __init__(self, cache_path: PathLike):
@@ -45,10 +50,6 @@ class XpuGraphLocalCache(XpuGraphCache):
         cache_path = os.path.abspath(cache_path)
         os.makedirs(cache_path, exist_ok=True)
         self._path = cache_path
-
-        # FIXME: Currently we manually set inductor cache dir for vendor compiler
-        #        environs should not be tainted once AOT pipeline is ready
-        os.environ["TORCHINDUCTOR_CACHE_DIR"] = os.path.join(cache_path, "inductor")
 
     def save_gm(
         self, key, value: torch.fx.GraphModule, expire=None
@@ -81,7 +82,29 @@ class XpuGraphLocalCache(XpuGraphCache):
         fname = f"xpu_graph_{key}.pt"
         artifact_cache = os.path.join(self._path, fname)
         return artifact_cache
+        
+    def _set_cache_ctx(self):
+        orig_ctx = {}
+        if "TORCHINDUCTOR_CACHE_DIR" in os.environ:
+            orig_ctx["TORCHINDUCTOR_CACHE_DIR"] = os.environ["TORCHINDUCTOR_CACHE_DIR"]
+        if "TRITON_CACHE_DIR" in os.environ:
+            orig_ctx["TRITON_CACHE_DIR"] = os.environ["TRITON_CACHE_DIR"]
 
+        # FIXME: Currently we manually set inductor cache dir for vendor compiler
+        #        environs should not be tainted once AOT pipeline is ready
+        os.environ["TORCHINDUCTOR_CACHE_DIR"] = os.path.join(self._path, "inductor")
+        os.environ['TRITON_CACHE_DIR'] = os.path.join(self._path, 'triton')
+        return orig_ctx
+        
+    def _restore_cache_ctx(self, orig_ctx):
+        if "TORCHINDUCTOR_CACHE_DIR" in orig_ctx:
+            os.environ["TORCHINDUCTOR_CACHE_DIR"] = orig_ctx["TORCHINDUCTOR_CACHE_DIR"]
+        else:
+            del os.environ["TORCHINDUCTOR_CACHE_DIR"]
+        if "TRITON_CACHE_DIR" in orig_ctx:
+            os.environ["TRITON_CACHE_DIR"] = orig_ctx["TRITON_CACHE_DIR"]
+        else:
+            del os.environ["TRITON_CACHE_DIR"]
 
 def no_cache():
     return XpuGraphCache()


### PR DESCRIPTION
- Description: control TRITON_CACHE_DIR as well in xpu_graph cache manager
  * Bug: when inductor is not enabled, triton cache dir for replacement modules won't be controlled by xpu-graph
  * Fix: set env_var  in XpuGraphLocalCache