### PR TITLE
Remove tmo dep in training

### DIFF
--- a/xpu_graph/passes/patterns/targets/mlu/fuse_add_norm.py
+++ b/xpu_graph/passes/patterns/targets/mlu/fuse_add_norm.py
@@ -4,7 +4,6 @@ import operator
 import torch
 from torch import nn, fx
 import torch_mlu
-import torch_mlu_ops
 from xpu_graph.config import OptLevel
 from xpu_graph.passes.patterns.pattern import Pattern
 from xpu_graph.utils import logger
@@ -14,7 +13,6 @@ from ...utils.check_ops import (
     check_view,
     check_getitem_op,
 )
-
 
 class FusedNormReplacement(nn.Module):
     def forward(
@@ -28,6 +26,7 @@ class FusedNormReplacement(nn.Module):
         store_output_before_norm,
         norm_type,
     ):
+        import torch_mlu_ops
         if bias is None:
             bias = torch.zeros_like(weight)
         dtype = torch.promote_types(input.dtype, residual.dtype)

--- a/xpu_graph/passes/patterns/targets/mlu/fuse_addbmm.py
+++ b/xpu_graph/passes/patterns/targets/mlu/fuse_addbmm.py
@@ -3,7 +3,6 @@ from typing import Optional
 import torch
 from torch import nn, fx
 import torch_mlu
-import torch_mlu_ops
 from xpu_graph.config import OptLevel
 from xpu_graph.passes.patterns.pattern import Pattern
 from xpu_graph.utils import logger
@@ -18,7 +17,6 @@ from ...utils.check_ops import (
     get_shape,
     get_dtype,
 )
-
 
 class FusedBAddBMMReplacement(nn.Module):
     def forward(self, input1, input2, bias, bmm_shape, output_shape, output_dtype):

--- a/xpu_graph/passes/patterns/targets/mlu/fuse_ffn.py
+++ b/xpu_graph/passes/patterns/targets/mlu/fuse_ffn.py
@@ -3,13 +3,11 @@ from typing import Optional
 import torch
 from torch import nn, fx
 import torch_mlu
-import torch_mlu_ops
 
 from xpu_graph.passes.patterns.pattern import Pattern
 from xpu_graph.utils import logger
 from xpu_graph.config import OptLevel
 from ...utils.check_ops import check_view
-
 
 class FusedFFNReplacement(nn.Module):
     def forward(
@@ -40,6 +38,7 @@ class FusedFFNReplacement(nn.Module):
 def _is_ffn(
     node: fx.Node,
 ) -> tuple[bool, Optional[fx.Node], Optional[fx.Node], Optional[fx.Node]]:
+    import torch_mlu_ops
     if (node.target != "mlu_tmo_fused_matmul_1_replacement") and (
         node.target != "mlu_tmo_fused_matmul_2_replacement"
     ):

--- a/xpu_graph/passes/patterns/targets/mlu/fuse_flash_attention.py
+++ b/xpu_graph/passes/patterns/targets/mlu/fuse_flash_attention.py
@@ -1,7 +1,6 @@
 import torch
 from torch import nn, fx
 import torch_mlu
-import torch_mlu_ops
 from typing import List, Tuple
 
 from xpu_graph import OptLevel
@@ -31,6 +30,7 @@ def tmo_fa_forward(
     output_shape: List[int],
     output_dtype: torch.dtype,
 ) -> torch.Tensor:
+    import torch_mlu_ops
     if query.dtype != output_dtype:
         query = query.to(output_dtype)
     if key.dtype != output_dtype:

--- a/xpu_graph/passes/patterns/targets/mlu/fuse_layernorm_mm.py
+++ b/xpu_graph/passes/patterns/targets/mlu/fuse_layernorm_mm.py
@@ -4,7 +4,6 @@ import operator
 import torch
 from torch import nn, fx
 import torch_mlu
-import torch_mlu_ops
 from xpu_graph.config import OptLevel
 from xpu_graph.passes.patterns.pattern import Pattern
 from xpu_graph.utils import logger
@@ -18,6 +17,7 @@ class FusedLayernormMMReplacement(nn.Module):
         self, inputs, norm_weight, norm_bias, eps, q_weight, q_bias, trans_b, shape_param,
         k_weight=None, k_bias=None, v_weight=None, v_bias=None,
     ):
+        import torch_mlu_ops
         if inputs.stride()[-1] != 1:
             inputs = inputs.contiguous()
         

--- a/xpu_graph/passes/patterns/targets/mlu/fuse_linear_attention.py
+++ b/xpu_graph/passes/patterns/targets/mlu/fuse_linear_attention.py
@@ -1,7 +1,6 @@
 import torch
 from torch import nn, fx
 import torch_mlu
-import torch_mlu_ops
 from typing import List, Tuple
 
 from xpu_graph.passes.patterns.pattern import Pattern

--- a/xpu_graph/passes/patterns/targets/mlu/fuse_matmul.py
+++ b/xpu_graph/passes/patterns/targets/mlu/fuse_matmul.py
@@ -3,7 +3,6 @@ from typing import Optional, Tuple, Union
 import torch
 from torch import nn, fx
 import torch_mlu
-import torch_mlu_ops
 from xpu_graph.utils import logger
 from xpu_graph.config import OptLevel
 from xpu_graph.passes.patterns.pattern import Pattern
@@ -175,6 +174,7 @@ class FusedMatMulReplacement(nn.Module):
     def forward(
         self, inputs, input_shape, weight, weight_shape, trans_b, bias, shape_param, act
     ):
+        import torch_mlu_ops
 
         # input last dim must be contiguous.
         if inputs.stride()[-1] != 1:

--- a/xpu_graph/passes/patterns/targets/mlu/fuse_slice_where_cat.py
+++ b/xpu_graph/passes/patterns/targets/mlu/fuse_slice_where_cat.py
@@ -3,8 +3,6 @@ from typing import Optional
 import torch
 from torch import nn, fx
 import torch_mlu
-import torch_mlu_ops
-
 from xpu_graph.passes.patterns.pattern import Pattern
 from xpu_graph.utils import logger
 from xpu_graph.config import OptLevel

--- a/xpu_graph/passes/patterns/targets/mlu/repeat_to_expand.py
+++ b/xpu_graph/passes/patterns/targets/mlu/repeat_to_expand.py
@@ -3,7 +3,6 @@ from typing import Optional, Tuple, Union
 import torch
 from torch import nn, fx
 import torch_mlu
-import torch_mlu_ops
 from xpu_graph.utils import logger
 from xpu_graph.config import OptLevel
 from xpu_graph.passes.patterns.pattern import Pattern

--- a/xpu_graph/passes/patterns/targets/mlu/structure_replacements.py
+++ b/xpu_graph/passes/patterns/targets/mlu/structure_replacements.py
@@ -1,7 +1,6 @@
 import torch
 import torch.fx as fx
 import torch_mlu
-import torch_mlu_ops
 
 from .triton_kernel.fused_slice import (
     fused_slice_low,
@@ -11,9 +10,9 @@ from .triton_kernel.fused_slice_cat import (
     fused_slice_cat,
 )
 
-
 class RMSNormModule(torch.nn.Module):
     def forward(self, inputs, weights, epsilon):
+        import torch_mlu_ops
         return torch_mlu_ops.fused_rms_norm(
             inputs, None, weights, None, None, epsilon, False
         )


### PR DESCRIPTION
1. torch_mlu_ops为大模型推理设计，没有反向算子，也不保证训练前向的精度。
2. 在is_traing=True时，去掉torch_mlu_ops的依赖，也不会报错。
