### PR TITLE
fix(aclgraph):Fix  copy bug when using xpu_graph on torch 2.3

### DIFF
--- a/tests/npu/test_aclgraph_tree.py
+++ b/tests/npu/test_aclgraph_tree.py
@@ -1,0 +1,33 @@
+import torch
+import torch_npu
+import inductor_npu
+import xpu_graph
+from xpu_graph.test_utils import is_similar
+from xpu_graph.config import OptLevel
+
+class GraphTest1(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, hidden_states):
+        tmp1 = torch.nn.functional.relu(hidden_states)
+        tmp2 = tmp1.mul(2)
+        tmp3 = tmp2 + 12.0
+        return tmp3
+
+gt1 = GraphTest1().npu()
+
+def aclgraph_tree_test(xpu_graph, func):
+    with torch.no_grad():
+        inp = torch.randn(4, 32).npu()
+        torch._inductor.config.triton.cudagraphs = True
+        compiled = torch.compile(func, backend=xpu_graph, dynamic=False)
+        for i in range(5):
+            compiled(inp)
+        out = compiled(inp)
+        out1 = func(inp)
+        assert is_similar(out1.float(), out.float())
+
+if __name__ == "__main__":
+    xpu_graph_backend = xpu_graph.npu_compiler(opt_level=OptLevel.level2)
+    aclgraph_tree_test(xpu_graph_backend, gt1)

--- a/xpu_graph/backends/npu.py
+++ b/xpu_graph/backends/npu.py
@@ -9,6 +9,8 @@ def npu_compile(
     from torch._inductor.compile_fx import compile_fx
     from torch._inductor import config
     from torch._inductor import list_mode_options
+    if tracing_context := torch._guards.TracingContext.try_get():
+        tracing_context.num_mutation_input = module.num_mutation_input
     # default means None
     mode = config_dict.get("mode", "default")
     dynamic = config_dict.get("dynamic", False)
@@ -29,3 +31,30 @@ def npu_compile(
     )
 
     return compiled_module
+
+def get_torch_version():
+    torch_version = torch.__version__
+    if '+' in torch_version:
+        return torch_version.split('+')[0]
+    return torch_version
+
+if get_torch_version() <= '2.3.1':
+    def _patch_inductor_for_aclgraph():
+        # Func `num_fw_fixed_arguments` is used to calulate the num of fixed args.
+        # Patch it to fix a bug caused by xpu_graph, which will lead to more inplace copy.
+        def new_num_fw_fixed_arguments(dynamo_gm_num_inputs: int, aot_fw_gm_num_inputs: int):
+            "Computes the number of inputs to the aot fw graph which have fixed addresses (params and buffers)"
+            if tracing_context := torch._guards.TracingContext.try_get():
+                try:
+                    dynamo_gm_num_inputs = tracing_context.num_mutation_input
+                except AttributeError:
+                    pass
+
+            num_rng_seed_offset_inputs = (
+                2 if torch._functorch.config.functionalize_rng_ops else 0
+            )
+            return aot_fw_gm_num_inputs - dynamo_gm_num_inputs - num_rng_seed_offset_inputs
+
+        torch._inductor.utils.num_fw_fixed_arguments = new_num_fw_fixed_arguments
+
+    _patch_inductor_for_aclgraph()


### PR DESCRIPTION
- BUG描述: xpu_graph在inductor(compile_fx)之前使用aot_autograd来获取aten op，但是inductor本身也会再次调用aot_autograd，在普通场景无异常，在2.3版本+cudagraph的场景，由于连续调用导致inductor侧的aot_autograd无法正确区分哪些tensor是输入，哪些tensor是param，进而导致aclgraph出现大量冗余的inplace_copy影响性能。
- BUG修复:在2.3.1版本及以下，通过patch torch的函数并使用tracing_context来将正确的input数量透传到inductor，从而正确使aclgraph正确识别需要copy的tensor数量。