### PR TITLE
fix(FoldReduce): avoid fold_reduce from using symint in shapes

### DIFF
--- a/tests/common/test_change_trensor_like.py
+++ b/tests/common/test_change_trensor_like.py
@@ -1,0 +1,50 @@
+import pytest
+import torch
+import xpu_graph
+from xpu_graph.test_utils import need_xpu_graph_logs, skip_xpu_graph_cache
+
+
+def fn0(a):
+    output = torch.ones_like(a)
+    return output
+
+def fn1(a):
+    output = torch.zeros_like(a)
+    return output
+
+def fn2(a):
+    output = torch.ones_like(a)
+    return output
+
+def tensorlike_test(xpu_graph, func):
+    compiled = torch.compile(func, backend=xpu_graph, dynamic=False)
+    a = torch.randn(128, 64)
+    res = func(a)
+    res1 = compiled(a)
+    for i in range(len(res)):
+        assert torch.equal(res[i].float(), res1[i].float())
+
+
+class TestTensorLike:
+    def setup_class(self):
+        config = xpu_graph.config.XpuGraphConfig(is_training=False)
+        self.xpu_graph = xpu_graph.compiler.XpuGraph(config)
+
+    @pytest.mark.parametrize(
+        "pattern_func",
+        [
+            fn0,
+            fn1,
+        ],
+    )
+    def test_tensorlike_patterns(self, caplog, pattern_func):
+        with need_xpu_graph_logs(), skip_xpu_graph_cache(self.xpu_graph):
+            tensorlike_test(self.xpu_graph, pattern_func)
+        assert "Pattern.ChangeTensorLike changed graph" in caplog.text
+
+
+if __name__ == "__main__":
+    config = xpu_graph.config.XpuGraphConfig(is_training=False, debug=True)
+    xpu_graph = xpu_graph.compiler.XpuGraph(config)
+    tensorlike_test(xpu_graph, fn0)
+    tensorlike_test(xpu_graph, fn1)

--- a/tests/common/test_change_trensor_like.py
+++ b/tests/common/test_change_trensor_like.py
@@ -16,8 +16,24 @@ def fn2(a):
     output = torch.ones_like(a)
     return output
 
+
+def inner_fn(zeros, ones):
+        zeros = torch.zeros_like(zeros)
+        ones = torch.ones_like(ones)
+        output = torch.concat([zeros, ones], dim=0)
+        return output
+    
+def fn3(a):
+    b = torch.sum(a, dim=1)
+    outputs = []
+    for i in range(10):
+        output = inner_fn(a[b>=i], a[b<i])
+        outputs.append(output)
+    output = torch.stack(outputs, dim=0)
+    return output
+
 def tensorlike_test(xpu_graph, func):
-    compiled = torch.compile(func, backend=xpu_graph, dynamic=False)
+    compiled = torch.compile(func, backend=xpu_graph, dynamic=None)
     a = torch.randn(128, 64)
     res = func(a)
     res1 = compiled(a)
@@ -35,12 +51,15 @@ class TestTensorLike:
         [
             fn0,
             fn1,
+            fn2,
+            fn3,
         ],
     )
     def test_tensorlike_patterns(self, caplog, pattern_func):
         with need_xpu_graph_logs(), skip_xpu_graph_cache(self.xpu_graph):
             tensorlike_test(self.xpu_graph, pattern_func)
-        assert "Pattern.ChangeTensorLike changed graph" in caplog.text
+        if pattern_func not in [fn3]:
+            assert "Pattern.ChangeTensorLike changed graph" in caplog.text 
 
 
 if __name__ == "__main__":
@@ -48,3 +67,5 @@ if __name__ == "__main__":
     xpu_graph = xpu_graph.compiler.XpuGraph(config)
     tensorlike_test(xpu_graph, fn0)
     tensorlike_test(xpu_graph, fn1)
+    tensorlike_test(xpu_graph, fn2)
+    tensorlike_test(xpu_graph, fn3)

--- a/tests/common/test_fold_reduce.py
+++ b/tests/common/test_fold_reduce.py
@@ -1,0 +1,64 @@
+import pytest
+import torch
+import xpu_graph
+from xpu_graph.test_utils import need_xpu_graph_logs, skip_xpu_graph_cache
+
+
+def fn0(a):
+    output = torch.sum(a, dim=1)
+    return output
+
+def fn1(a):
+    output = torch.sum(a, dim=3, keepdim=True)
+    return output
+
+def fn2(a):
+    output = torch.sum(a, dim=1, keepdim=False)
+    return output
+
+def fn3(a):
+    output = torch.sum(a, dim=(1, 3), keepdim=False)
+    return output
+
+def fn4(a):
+    output = torch.sum(a, dim=(1, 3), keepdim=True)
+    return output
+
+def reduce_test(xpu_graph, func):
+    compiled = torch.compile(func, backend=xpu_graph, dynamic=False)
+    a = torch.randn(128, 1, 64, 1)
+    res = func(a)
+    res1 = compiled(a)
+    for i in range(len(res)):
+        assert torch.equal(res[i].float(), res1[i].float())
+
+
+class TestReduce:
+    def setup_class(self):
+        config = xpu_graph.config.XpuGraphConfig(is_training=False)
+        self.xpu_graph = xpu_graph.compiler.XpuGraph(config)
+
+    @pytest.mark.parametrize(
+        "pattern_func",
+        [
+            fn0,
+            fn1,
+            fn2,
+            fn3,
+            fn4,
+        ],
+    )
+    def test_reduce_patterns(self, caplog, pattern_func):
+        with need_xpu_graph_logs(), skip_xpu_graph_cache(self.xpu_graph):
+            reduce_test(self.xpu_graph, pattern_func)
+        assert "Pattern.FoldReduce changed graph" in caplog.text
+
+
+if __name__ == "__main__":
+    config = xpu_graph.config.XpuGraphConfig(is_training=False, debug=True)
+    xpu_graph = xpu_graph.compiler.XpuGraph(config)
+    reduce_test(xpu_graph, fn0)
+    reduce_test(xpu_graph, fn1)
+    reduce_test(xpu_graph, fn2)
+    reduce_test(xpu_graph, fn3)
+    reduce_test(xpu_graph, fn4)

--- a/tests/common/test_fold_stack.py
+++ b/tests/common/test_fold_stack.py
@@ -1,0 +1,52 @@
+import pytest
+import torch
+import xpu_graph
+from xpu_graph.test_utils import need_xpu_graph_logs, skip_xpu_graph_cache
+
+
+def fn0(a):
+    output = torch.stack([a], dim=0)
+    return output
+
+def fn1(a):
+    output = torch.stack([a], dim=1)
+    return output
+
+def fn2(a):
+    output = torch.stack([a], dim=2)
+    return output
+
+def stack_test(xpu_graph, func):
+    compiled = torch.compile(func, backend=xpu_graph, dynamic=False)
+    a = torch.randn(128, 64)
+    res = func(a)
+    res1 = compiled(a)
+    for i in range(len(res)):
+        assert torch.equal(res[i].float(), res1[i].float())
+
+
+class TestStack:
+    def setup_class(self):
+        config = xpu_graph.config.XpuGraphConfig(is_training=False)
+        self.xpu_graph = xpu_graph.compiler.XpuGraph(config)
+
+    @pytest.mark.parametrize(
+        "pattern_func",
+        [
+            fn0,
+            fn1,
+            fn2,
+        ],
+    )
+    def test_stack_patterns(self, caplog, pattern_func):
+        with need_xpu_graph_logs(), skip_xpu_graph_cache(self.xpu_graph):
+            stack_test(self.xpu_graph, pattern_func)
+        assert "Pattern.FoldStack changed graph" in caplog.text
+
+
+if __name__ == "__main__":
+    config = xpu_graph.config.XpuGraphConfig(is_training=False, debug=True)
+    xpu_graph = xpu_graph.compiler.XpuGraph(config)
+    stack_test(xpu_graph, fn0)
+    stack_test(xpu_graph, fn1)
+    stack_test(xpu_graph, fn2)

--- a/xpu_graph/compiler.py
+++ b/xpu_graph/compiler.py
@@ -173,13 +173,13 @@ class XpuGraph:
 
             logger.info("unlift graph start...")
             logger.debug(f"before unlift, graph like:\n {exported_gm.graph}")
-            unlfited_gm = unlift_exported_gm(
+            unlifted_gm = unlift_exported_gm(
                 dynamo_gm, exported_gm, gs, freeze=self._config.freeze
             )
             logger.info("unlift graph complete")
-            logger.debug(f"after unlift, graph like:\n {unlfited_gm.graph}")
+            logger.debug(f"after unlift, graph like:\n {unlifted_gm.graph}")
 
-            xpu_gm = _compiler(unlfited_gm, example_inputs, stage=FxStage.inference)
+            xpu_gm = _compiler(unlifted_gm, example_inputs, stage=FxStage.inference)
 
         return xpu_gm
 

--- a/xpu_graph/config.py
+++ b/xpu_graph/config.py
@@ -59,7 +59,8 @@ class XpuGraphConfig:
     def _reset_config_with_env(self):
         import os
 
-        self.debug = os.getenv("XPUGRAPH_DEBUG", "0") == "1"  # 1: enable 0: disable
+        if os.getenv("XPUGRAPH_DEBUG") is not None:
+            self.debug = os.getenv("XPUGRAPH_DEBUG", "0") == "1"  # 1: enable 0: disable
 
         opt_level_env = os.getenv("XPUGRAPH_OPT_LEVEL", str(self.opt_level.value))
         if opt_level_env == "0":

--- a/xpu_graph/passes/patterns/common/change_tensor_like.py
+++ b/xpu_graph/passes/patterns/common/change_tensor_like.py
@@ -1,5 +1,6 @@
 import torch
 import torch.fx as fx
+from torch import SymInt
 from xpu_graph.fx_utils import FxStage
 from xpu_graph.passes.patterns.pattern import Pattern
 
@@ -15,8 +16,11 @@ class ChangeTensorLike(Pattern):
         candidates = [node for node in gm.graph.nodes if node.op == 'call_function' and node.target in tensor_like_map]
 
         for like in candidates:
-            changed = True
             inp = like.args[0]
+            if any([isinstance(s, SymInt) for s in like.meta['tensor_meta'].shape]):
+                # FIXME: use shape env to get the real shape
+                continue
+            changed = True
             with gm.graph.inserting_before(like):
                 tensor = gm.graph.call_function(
                     tensor_like_map[like.target],

--- a/xpu_graph/passes/patterns/common/fold_reduce.py
+++ b/xpu_graph/passes/patterns/common/fold_reduce.py
@@ -2,6 +2,7 @@ import torch
 import torch.fx as fx
 from xpu_graph.fx_utils import FxStage
 from xpu_graph.passes.patterns.pattern import Pattern
+from xpu_graph.passes.patterns.utils.check_ops import get_input_kw_node, get_input_node
 
 reduce_tup = (torch.ops.aten.sum.dim_IntList,)
 
@@ -13,18 +14,29 @@ class FoldReduce(Pattern):
         candidates = [node for node in gm.graph.nodes if node.op == 'call_function' and node.target in reduce_tup]
 
         for reduce in candidates:
-            inp = reduce.args[0]
-            dim = reduce.args[1][0]
-            if inp.meta['tensor_meta'].shape[dim] == 1:
+            inp = get_input_node(reduce, 0)
+            dims = get_input_kw_node(reduce, "dim")
+            if not isinstance(dims, list):
+                dims = [dims]
+            keep_dim = get_input_kw_node(reduce, "keepdim") or False
+            if all([inp.meta['tensor_meta'].shape[dim] == 1 for dim in dims]):
                 changed = True
                 with gm.graph.inserting_before(reduce):
-                    view = gm.graph.call_function(
-                        torch.ops.aten.view.default,
-                        args=(
-                            inp,
-                            reduce.meta['tensor_meta'].shape
+                    if keep_dim:
+                        view = gm.graph.call_function(
+                            torch.ops.aten.clone.default,
+                            args=(
+                                inp,
+                            )
                         )
-                    )
+                    else:
+                        view = gm.graph.call_function(
+                            torch.ops.aten.squeeze.dims,
+                            args=(
+                                inp,
+                                dims,
+                            )
+                        )
                     reduce.replace_all_uses_with(view)
                     gm.graph.erase_node(reduce)
 

--- a/xpu_graph/passes/patterns/common/fold_reduce.py
+++ b/xpu_graph/passes/patterns/common/fold_reduce.py
@@ -23,12 +23,7 @@ class FoldReduce(Pattern):
                 changed = True
                 with gm.graph.inserting_before(reduce):
                     if keep_dim:
-                        view = gm.graph.call_function(
-                            torch.ops.aten.clone.default,
-                            args=(
-                                inp,
-                            )
-                        )
+                        view = inp
                     else:
                         view = gm.graph.call_function(
                             torch.ops.aten.squeeze.dims,

--- a/xpu_graph/passes/patterns/common/fold_stack.py
+++ b/xpu_graph/passes/patterns/common/fold_stack.py
@@ -2,6 +2,7 @@ import torch
 import torch.fx as fx
 from xpu_graph.fx_utils import FxStage
 from xpu_graph.passes.patterns.pattern import Pattern
+from xpu_graph.passes.patterns.utils.check_ops import get_input_node, get_input_kw_node
 
 class FoldStack(Pattern):
     _stages = [FxStage.inference, FxStage.pregrad, FxStage.forward, FxStage.backward]
@@ -11,16 +12,17 @@ class FoldStack(Pattern):
         candidates = [node for node in gm.graph.nodes if node.op == 'call_function' and node.target == torch.ops.aten.stack.default]
 
         for stack in candidates:
-            inps = stack.args[0]
+            inps = get_input_node(stack, 0)
             if len(inps) == 1:
                 changed = True
                 inp = inps[0]
+                dim = get_input_kw_node(stack, 'dim')
                 with gm.graph.inserting_before(stack):
                     view = gm.graph.call_function(
-                        torch.ops.aten.view.default,
+                        torch.ops.aten.unsqueeze.default,
                         args=(
                             inp,
-                            stack.meta['tensor_meta'].shape
+                            dim
                         )
                     )
                     stack.replace_all_uses_with(view)

--- a/xpu_graph/passes/patterns/common/fold_view.py
+++ b/xpu_graph/passes/patterns/common/fold_view.py
@@ -3,21 +3,30 @@ import torch.fx as fx
 from xpu_graph.fx_utils import FxStage
 from xpu_graph.passes.patterns.pattern import Pattern
 
+
 class FoldView0(Pattern):
-    '''
+    """
     Fold aten.view which inp.shape == target_shape
-    '''
+    """
+
     _stages = [FxStage.inference, FxStage.pregrad, FxStage.forward, FxStage.backward]
 
     def process(self, gm: fx.GraphModule):
         changed = False
-        view_tup = (torch.ops.aten.view.default, torch.ops.aten._unsafe_view.default,)
-        candidates = [node for node in gm.graph.nodes if node.op == 'call_function' and node.target in view_tup]
+        view_tup = (
+            torch.ops.aten.view.default,
+            torch.ops.aten._unsafe_view.default,
+        )
+        candidates = [
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function" and node.target in view_tup
+        ]
 
         for view in candidates:
             inp = view.args[0]
             target_shape = view.args[1]
-            if target_shape == list(inp.meta['tensor_meta'].shape):
+            if target_shape == list(inp.meta["tensor_meta"].shape):
                 changed = True
 
                 view.replace_all_uses_with(inp)
@@ -28,23 +37,42 @@ class FoldView0(Pattern):
         return changed
 
 
+_view_like_ops = (
+    torch.ops.aten.view.default,
+    torch.ops.aten._unsafe_view.default,
+    torch.ops.aten.squeeze.default,
+    torch.ops.aten.squeeze.dim,
+    torch.ops.aten.squeeze.dims,
+    torch.ops.aten.unsqueeze.default,
+)
+
+
 class FoldView1(Pattern):
-    '''
+    """
     Fold aten.view(aten.view) -> aten.view
-    '''
+    """
+
     _stages = [FxStage.inference, FxStage.pregrad, FxStage.forward]
 
     def process(self, gm: fx.GraphModule):
         changed = False
-        view_tup = (torch.ops.aten.view.default, torch.ops.aten._unsafe_view.default,)
-        pattern_tup = (torch.ops.aten.view.default, torch.ops.aten._unsafe_view.default, torch.ops.aten.squeeze.default, torch.ops.aten.unsqueeze.default)
-        candidates = [node for node in gm.graph.nodes if node.op == 'call_function' and node.target in view_tup]
+        view_tup = (
+            torch.ops.aten.view.default,
+            torch.ops.aten._unsafe_view.default,
+        )
+        candidates = [
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function" and node.target in view_tup
+        ]
 
         for view in candidates:
             inp = view.args[0]
-            if isinstance(inp, fx.Node) and \
-                inp.op == 'call_function' and \
-                inp.target in pattern_tup:
+            if (
+                isinstance(inp, fx.Node)
+                and inp.op == "call_function"
+                and inp.target in _view_like_ops
+            ):
                 changed = True
                 view.replace_input_with(inp, inp.args[0])
 


### PR DESCRIPTION
* Bug: using shape from tensor_meta may introduce symints, which is unbacked now
* Fix: use squeeze to avoid using view ops with shapes in fold_reduce