### PR TITLE
fix(cse): fix torch's CSE triger condition too strict

### DIFF
--- a/tests/common/test_cse.py
+++ b/tests/common/test_cse.py
@@ -7,7 +7,7 @@ from xpu_graph.test_utils import (
 
 
 def test_cse(caplog):
-    def can_cse(x, y):
+    def can_cse_case_1(x, y):
         z = x + y
         zz = x + y
         return z + zz
@@ -15,11 +15,57 @@ def test_cse(caplog):
     xpu_graph_backend = XpuGraph(XpuGraphConfig(is_training=False, enable_cache=False))
     with need_xpu_graph_logs():
         compiled_func = torch.compile(
-            can_cse,
+            can_cse_case_1,
             backend=xpu_graph_backend,
         )
         in1, in2 = torch.randn(10), torch.randn(10)
         res = compiled_func(in1, in2)
-        expect = can_cse(in1, in2)
+        expect = can_cse_case_1(in1, in2)
 
     assert is_similar(res, expect) and "Optimizer.Cse changed graph" in caplog.text
+
+    def can_cse_case_2(x):
+        return x, x.reshape(-1) + x.reshape(-1)
+
+    xpu_graph_backend = XpuGraph(XpuGraphConfig(is_training=False, enable_cache=False))
+
+    with need_xpu_graph_logs():
+        compiled_func = torch.compile(
+            can_cse_case_2,
+            backend=xpu_graph_backend,
+        )
+        res = compiled_func(torch.randn(10))
+        expect = can_cse_case_2(torch.randn(10))
+
+    assert "Optimizer.Cse changed graph" in caplog.text
+
+    # https://github.com/pytorch/pytorch/issues/88813
+    def not_cse_case_1(val: torch.Tensor):
+        return val * 2, val * 2
+
+    compiler = XpuGraph(XpuGraphConfig(is_training=False))
+
+    compiled_func = torch.compile(not_cse_case_1, backend=compiler, dynamic=False)
+    res0, res1 = compiled_func(torch.randn(100))
+
+    assert res0.untyped_storage().data_ptr() != res1.untyped_storage().data_ptr()
+
+    # https://github.com/pytorch/pytorch/issues/114344
+    def not_cse_case_2(val: torch.Tensor):
+        with torch.no_grad():
+            out0 = val + 1
+        out1 = val + 1
+        return out0, out1
+
+    compiled_func1 = torch.compile(not_cse_case_2, backend=compiler, dynamic=False)
+    res0, res1 = compiled_func1(torch.randn(100))
+    assert res0.untyped_storage().data_ptr() != res1.untyped_storage().data_ptr()
+
+    # https://github.com/pytorch/pytorch/pull/134726#discussion_r1738774371
+    def not_cse_case_3(val: torch.Tensor):
+        x, y = val * 2, val * 2
+        return x[0], y[0]
+
+    compiled_func2 = torch.compile(not_cse_case_3, backend=compiler, dynamic=False)
+    res0, res1 = compiled_func2(torch.randn(100))
+    assert res0.untyped_storage().data_ptr() != res1.untyped_storage().data_ptr()

--- a/xpu_graph/passes/cse.py
+++ b/xpu_graph/passes/cse.py
@@ -1,14 +1,168 @@
-import typing
+from typing import Callable
 
 import torch
 import torch.fx as fx
 from torch.utils._pytree import tree_flatten
+from torch.multiprocessing.reductions import StorageWeakRef
 
 from xpu_graph.passes.optimizer import Optimizer
 
+aten = torch.ops.aten
+
+rand_ops = [
+    aten.dropout,
+    aten._fused_dropout,
+    aten._standard_gamma,
+    aten.bernoulli,
+    aten.multinomial,
+    aten.native_dropout,
+    aten.normal,
+    aten.poisson,
+    aten.binomial,
+    aten.rrelu,
+    aten.rand_like,
+    aten.rand,
+    aten.randint,
+    aten.randn,
+    aten.randperm,
+]
+
+
+def get_aten_target(node: fx.Node) -> Callable:
+    if hasattr(node.target, "overloadpacket"):
+        return node.target.overloadpacket
+    return node.target
+
+
+# This method is adapt from https://github.com/pytorch/pytorch/blob/main/torch/_functorch/compile_utils.py#L42
+# After the commit(https://github.com/pytorch/pytorch/commit/43c9b4e0e690a07fe69633de2bbf45e585a40e03), upstream‘s
+# CSE is a little more strick, which will forbid all nodes who have same Storage with graph's outputs to enter CSE Pass.
+# But actually, we only need to forbid the storage's producer and graph's outputs only.
+# We fix this in xpu_graph temporarily, and we will commit a PR to Torch latter.
+# return a new copy of torch.fx.graph.Graph with CSE applied to the input graph
+def fx_graph_cse(fx_g: torch.fx.graph.Graph):
+    new_graph = fx.Graph()
+    env = {}  # map from node in the old graph to node in the new graph
+    hash_env = {}  # map from hash to a node in the new graph
+    token_map = {}  # map from hash to token
+
+    from torch._inductor.pattern_matcher import (
+        compute_mutation_region_ids,
+        same_mutation_regions,
+    )
+
+    compute_mutation_region_ids(fx_g)  # type: ignore[arg-type]
+
+    # Make a set of separate storages returned from the output, which will be preserved
+    # when pruning.  This prevents us from deduplicating returned tensors which have
+    # experienced identical operations, but are separate data structures in eager mode.
+    output_node: fx.Node = list(fx_g.nodes)[-1]
+    assert output_node.op == "output"
+
+    def checkable_node(node: fx.Node) -> bool:
+        """We can evaluate only nodes that represent tensors with defined storage."""
+        if "val" not in node.meta or not isinstance(node.meta["val"], torch.Tensor):
+            return False
+
+        try:
+            node.meta["val"].untyped_storage()
+        except NotImplementedError:
+            return False
+
+        return True
+
+    output_storages = {
+        StorageWeakRef(n.meta["val"].untyped_storage())
+        for n in output_node.all_input_nodes
+        if checkable_node(n)
+    }
+
+    output_storages_producers = set()
+    for n in fx_g.nodes:
+        if (
+            checkable_node(n)
+            and StorageWeakRef(n.meta["val"].untyped_storage()) in output_storages
+        ):
+            output_storages_producers.add(n)
+            output_storages.remove(StorageWeakRef(n.meta["val"].untyped_storage()))
+
+    output_node_and_storage_producer = (
+        set(output_node.all_input_nodes) | output_storages_producers
+    )
+
+    for n in fx_g.nodes:
+        # The placeholder, output, and get_attr nodes are copied to the new graph without change
+        # do not CSE away random operations
+        if (
+            n.op == "placeholder"
+            or n.op == "output"
+            or n.op == "get_attr"
+            or get_aten_target(n) in rand_ops
+            # aten.empty is non-deterministic, so don't CSE it.
+            # Also, aten.empty is almost always fusible into its consumer,
+            # so it's not worth CSEing.
+            or get_aten_target(n) is aten.empty
+            or n in output_node_and_storage_producer
+        ):
+            new_node = new_graph.node_copy(n, lambda x: env[x])
+            env[n] = new_node
+        else:  # n.op == 'call_function', should never see n.op == 'call_module' or 'call_method'
+            # substitute args and kwargs members to their mapping in env if exists
+            # specs can be used to reconstruct nested list/dictionaries
+            def substitute(arg_list):
+                arg_list, spec = tree_flatten(arg_list)
+                for i in range(len(arg_list)):
+                    v = arg_list[i]
+                    if isinstance(v, torch.fx.node.Node) and v in env:
+                        arg_list[i] = env[v]
+                    if isinstance(v, (torch.SymBool, torch.SymInt, torch.SymFloat)):
+                        arg_list[i] = v.node
+                return tuple(arg_list), spec
+
+            args, args_spec = substitute(n.args)
+            kwargs, kwargs_spec = substitute(n.kwargs)
+
+            # each token corresponds to a unique node
+            # nodes with the same token can be substituted
+            token = {
+                "target": n.target,
+                "args": args,
+                "args_spec": args_spec,
+                "kwargs": kwargs,
+                "kwargs_spec": kwargs_spec,
+            }
+
+            # hash substituted args to a number, do not hash specs because specs are not hashable
+            # We need to add type into hash to avoid situations like:
+            # hash((primals_2, 1.0)) == hash((primals_2, 1))
+            hash_arg = hash(
+                (tuple((a, type(a)) for a in args), tuple((a, type(a)) for a in kwargs))
+            )
+            hash_val = (n.target, hash_arg)
+
+            # check if a node has a substitute and can be eliminated
+            hash_val_in_hash_env = hash_val in hash_env
+            overwrite_due_to_mutation = False
+            if hash_val_in_hash_env and token_map[hash_val] == token:
+                duplicate_n_prev = hash_env[hash_val]
+                if same_mutation_regions(n, duplicate_n_prev):
+                    env[n] = duplicate_n_prev
+                    continue
+                else:
+                    # any futures duplicates should replace with n, not duplicate_n_prev
+                    overwrite_due_to_mutation = True
+
+            new_node = new_graph.node_copy(n, lambda x: env[x])
+            env[n] = new_node
+            if overwrite_due_to_mutation or not hash_val_in_hash_env:
+                hash_env[hash_val] = new_node
+                token_map[hash_val] = token
+
+    return new_graph
+
+
 class Cse(Optimizer):
     def process(self, gm: fx.GraphModule):
-        from torch._functorch.compile_utils import fx_graph_cse
         cse_graph = fx_graph_cse(gm.graph)
 
         changed = len(cse_graph.nodes) != len(gm.graph.nodes)


### PR DESCRIPTION
* Bug Description: After the commit(https://github.com/pytorch/pytorch/commit/43c9b4e0e690a07fe69633de2bbf45e585a40e03), upstream‘s CSE is a little more strict, which will forbid all nodes who have same Storage with graph's outputs to enter CSE Pass. But actually, we only need to forbid the storage's producer and graph's outputs only.
* BugFix: We fix this in xpu_graph temporarily, and we will commit a PR to Torch latter.