### PR TITLE
feat(target/mlu): enable repeat_to_expand in training

### DIFF
--- a/xpu_graph/passes/patterns/targets/mlu/repeat_to_expand.py
+++ b/xpu_graph/passes/patterns/targets/mlu/repeat_to_expand.py
@@ -6,6 +6,7 @@ import torch_mlu
 from xpu_graph.utils import logger
 from xpu_graph.config import OptLevel
 from xpu_graph.passes.patterns.pattern import Pattern
+from xpu_graph.fx_utils import FxStage
 from ...utils.check_ops import (
     get_shape,
 )
@@ -21,6 +22,7 @@ NodeType = fx.Node
 """
 class FusedGatherToCopy(Pattern):
     _opt_level = OptLevel.level1
+    _stages = [FxStage.inference, FxStage.pregrad]
 
     def process(self, graph_module: fx.GraphModule) -> bool:
         is_modified = False


### PR DESCRIPTION
    *In qianchuanv4 training, optimized scatter 23ms to 0.3ms .