### PR TITLE
fix(Pattern):Fix FusedSlice pattern mismatch caused by another pattern FusedSliceCat.

### DIFF
--- a/xpu_graph/passes/patterns/structure/fuse_slice.py
+++ b/xpu_graph/passes/patterns/structure/fuse_slice.py
@@ -28,7 +28,10 @@ def find_slice_nodes(graph_module):
             continue
         # skip output
         if len(node.users) == 1:
-            if next(iter(node.users)).target == "output":
+            # process side effects caused by FusedCatSlice.
+            if node.meta.get("changed_by_fused_slice_cat", False):
+                pass
+            elif next(iter(node.users)).target == "output":
                 continue
         if node.args[0] not in candi_nodes:
             candi_nodes[node.args[0]] = []

--- a/xpu_graph/passes/patterns/structure/fuse_slice_cat.py
+++ b/xpu_graph/passes/patterns/structure/fuse_slice_cat.py
@@ -118,6 +118,10 @@ def fuse_mixed_ops_and_catstack(graph_module: fx.GraphModule):
         if not is_slice:
             continue
 
+        # mark these slice node bacause this pattern will cause side effects.
+        for n in n_list:
+            n.meta['changed_by_fused_slice_cat'] = True
+
         new_cat_input = ori_cat_input[:start]
 
         slice_node = insert_fuse_slice(graph_module, node, src_node, slice_param)


### PR DESCRIPTION
** bug description: FusedSliceCat causes some side effects which will make FusedSlice's mismatch.
** bug fix: Mark slice nodes that are affected by FusedSliceCat, and detect it in pattern FusedSlice.