### PR TITLE
fix(fuse_slice_where_cat triton): Resolve the NRAM OOM issue

### DIFF
--- a/xpu_graph/passes/patterns/targets/mlu/triton_kernel/fused_slice_where_cat.py
+++ b/xpu_graph/passes/patterns/targets/mlu/triton_kernel/fused_slice_where_cat.py
@@ -95,8 +95,8 @@ def fuse_slice_where_cat(
     if slice_tensor.dtype == torch.float32:
         size_of_dtype = 4
     nram_limit = 416 * 1024
-    if (block_r * block_c * size_of_dtype) * 2 > nram_limit:
-        block_r = nram_limit // 2 // size_of_dtype // block_c
+    if (block_r * block_c * size_of_dtype) * 3 > nram_limit:
+        block_r = nram_limit // 3 // size_of_dtype // block_c
 
     loop = (slice_row + block_r - 1) // block_r
 

--- a/xpu_graph/passes/patterns/targets/mlu/triton_kernel/fused_slice_where_cat.py
+++ b/xpu_graph/passes/patterns/targets/mlu/triton_kernel/fused_slice_where_cat.py
@@ -95,6 +95,7 @@ def fuse_slice_where_cat(
     if slice_tensor.dtype == torch.float32:
         size_of_dtype = 4
     nram_limit = 416 * 1024
+    # 2 -> 3: input(slice_data) + output(slice_where) + where_data + Caching of intermediate results
     if (block_r * block_c * size_of_dtype) * 3 > nram_limit:
         block_r = nram_limit // 3 // size_of_dtype // block_c
 


### PR DESCRIPTION
fix(fuse_slice_where_cat triton): Resolve the NRAM OOM issue under large batch conditions.
    * Bug description: the memory calculation that causes NRAM OOM issues when the batch size gets really big (3000+)
    * Bugfix: triton_kernel/fused_slice_where_cat.py, modified the memory calculation