### PR TITLE
fix(fuse_norm_mm): fix the output dimension issue

### DIFF
--- a/tests/mlu/test_fuse_matmul.py
+++ b/tests/mlu/test_fuse_matmul.py
@@ -176,8 +176,12 @@ class TestMatMul:
     def test_matmul_patterns(self, caplog, pattern_func):
         with need_xpu_graph_logs(), skip_xpu_graph_cache(self.xpu_graph_backend):
             matmul_test(self.xpu_graph_backend, pattern_func)
-        assert "Pattern.FusedMatMul changed graph" in caplog.text
-
+        if pattern_func in [fn0, fn1, fn2, fn3]:
+            assert "Pattern.FusedMatMul changed graph" in caplog.text
+        elif pattern_func in [fn4, fn5, fn6, fn7, fn8, fn9, fn10, fn11, fn18]:
+            assert "Pattern.FusedMatMulAdd changed graph" in caplog.text
+        else:
+            assert "Pattern.FusedMatMulAct changed graph" in caplog.text
 
 if __name__ == "__main__":
     xpu_graph_backend = xpu_graph.mlu_compiler(

--- a/xpu_graph/passes/patterns/targets/mlu/fuse_layernorm_mm.py
+++ b/xpu_graph/passes/patterns/targets/mlu/fuse_layernorm_mm.py
@@ -48,6 +48,8 @@ class FusedLayernormMMReplacement(nn.Module):
             #head_size,
             #norm_out,
         )
+        if inputs.dim() == 2 and output.dim() == 3 and output.shape[0] == 1:
+            output = output.squeeze(0)
         if shape_param:
             output = output.view(shape_param)
         return output
@@ -83,7 +85,7 @@ def _is_layernorm_mm(
         q_bias_shape = q_bias.meta["tensor_meta"].shape
         if len(q_bias_shape) == 2 and q_bias_shape[0] > 1:
             return False, ()
-    
+
     return True, (inputs, norm_weight, norm_bias, eps, q_weight, q_bias, trans_b, shape_param)
     
 


### PR DESCRIPTION
fix(fuse_norm_mm): fix the output dimension issue
    * Bug description: tmo.attention_project expands a 2D input into 3D for computation, and its output is also 3D. This change in dimensionality can affect subsequent computations
    * Bugfix: targets/mlu/fuse_layernorm_mm.py
   
fix(fuse matmul): fix the issue of missing "tensor_meta" for the node
    * Bug description: The patterns for the three modes should be written separately. This way, each pattern will be recompiled individually, and the inputs of the matched module will have "tensor_meta".
    * Bugfix: targets/mlu/fuse_matmul.py