### PR TITLE
feat(fused_matmul): Refactor fused_matmul view handling and module naming

### DIFF
--- a/tests/mlu/test_combine_mm.py
+++ b/tests/mlu/test_combine_mm.py
@@ -1,0 +1,155 @@
+import pytest
+import torch
+import torch_mlu
+import xpu_graph
+from xpu_graph.config import OptLevel
+from xpu_graph.test_utils import (
+    assertTensorsEqual,
+    need_xpu_graph_logs,
+    skip_xpu_graph_cache,
+)
+
+device = "mlu:0"
+data_type = torch.float32
+
+
+def fn0(inputs, weight_list, bias_list):
+    inputs = inputs.squeeze(0)
+    outputs_original = []
+    for weight in weight_list:
+        outputs_original.append(inputs @ weight)
+    return outputs_original
+
+
+def fn1(inputs, weight_list, bias_list):
+    inputs = inputs.squeeze(0)
+    outputs_original = []
+    for weight in weight_list:
+        outputs_original.append(torch.bmm(inputs, weight))
+    return outputs_original
+
+
+def fn2(inputs, weight_list, bias_list):
+    inputs = inputs.squeeze(0)
+    outputs_original = []
+    for weight, bias in zip(weight_list, bias_list):
+        outputs_original.append(inputs @ weight + bias)
+    return outputs_original
+
+
+def fn3(inputs, weight_list, bias_list):
+    inputs = inputs.squeeze(0)
+    outputs_original = []
+    for weight, bias in zip(weight_list, bias_list):
+        outputs_original.append(inputs @ weight + bias)
+    return outputs_original
+
+
+def fn4(inputs, weight_list, bias_list):
+    inputs = inputs.squeeze(0)
+    outputs_original = []
+    for weight, bias in zip(weight_list, bias_list):
+        outputs_original.append(inputs @ weight + bias)
+    return outputs_original
+
+
+def fn5(inputs, weight_list, bias_list):
+    inputs = inputs.squeeze(0)
+    outputs_original = []
+    for weight, bias in zip(weight_list, bias_list):
+        outputs_original.append(torch.relu(inputs @ weight + bias))
+    return outputs_original
+
+
+def fn6(inputs, weight_list, bias_list):
+    input_list = inputs.split(inputs.shape[0] // len(weight_list), dim=0)
+    input_list = [i.squeeze(0) for i in input_list]
+    outputs_original = []
+    for input, weight in zip(input_list, weight_list):
+        outputs_original.append(torch.relu(input @ weight))
+    return outputs_original
+
+
+def combine_matmul_test(xpu_graph_backend, func):
+    T = 8
+    inputs = None
+    weight_list = None
+    bias_list = None
+    if func in [fn0, fn2, fn4, fn5]:
+        M, N, K = 5, 8, 7
+        inputs = torch.randn((1, M, N), device=device, dtype=data_type)
+        weight_list = [
+            torch.randn((N, K), device=device, dtype=data_type) for _ in range(T)
+        ]
+        if func == fn4:
+            bias_list = [
+                torch.randn((K), device=device, dtype=data_type) for _ in range(T)
+            ]
+        else:
+            bias_list = [
+                torch.randn((M, K), device=device, dtype=data_type) for _ in range(T)
+            ]
+    if func in [fn1, fn3]:
+        S = 3
+        M, N, K = 5, 6, 7
+        inputs = torch.randn((S, M, N), device=device, dtype=data_type)
+        weight_list = [
+            torch.randn((S, N, K), device=device, dtype=data_type) for _ in range(T)
+        ]
+        bias_list = [
+            torch.randn((S, M, K), device=device, dtype=data_type) for _ in range(T)
+        ]
+    if func == fn6:
+        M, N, K = 5, 8, 7
+        inputs = torch.randn((T, M, N), device=device, dtype=data_type)
+        weight_list = [
+            torch.randn((N, K), device=device, dtype=data_type) for _ in range(T)
+        ]
+        bias_list = None
+    res = func(inputs, weight_list, bias_list)
+    compiled = torch.compile(func, backend=xpu_graph_backend, dynamic=False)
+    res1 = compiled(inputs, weight_list, bias_list)
+    for i in range(T):
+        assertTensorsEqual(
+            res[i].cpu().float(),
+            res1[i].cpu().float(),
+            0.005,
+            use_MSE=True,
+            use_RAE=True,
+        )
+
+
+class TestCombineMatMul:
+    def setup_class(self):
+        self.xpu_graph_backend = xpu_graph.mlu_compiler(
+            is_training=False, opt_level=OptLevel.level2
+        )
+
+    @pytest.mark.parametrize(
+        "pattern_func",
+        [
+            fn0,
+            fn1,
+            fn2,
+            fn3,
+            fn4,
+            fn5,
+            fn6,
+        ],
+    )
+    def test_matmul_patterns(self, caplog, pattern_func):
+        with need_xpu_graph_logs(), skip_xpu_graph_cache(self.xpu_graph_backend):
+            combine_matmul_test(self.xpu_graph_backend, pattern_func)
+            assert "Pattern.FusedCombineMatMul changed graph" in caplog.text
+
+
+if __name__ == "__main__":
+    xpu_graph_backend = xpu_graph.mlu_compiler(
+        is_training=False, opt_level=OptLevel.level2, debug=False
+    )
+    # combine_matmul_test(xpu_graph_backend, fn0)
+    combine_matmul_test(xpu_graph_backend, fn1)
+    # combine_matmul_test(xpu_graph_backend, fn2)
+    # combine_matmul_test(xpu_graph_backend, fn4)
+    # combine_matmul_test(xpu_graph_backend, fn4)
+    # combine_matmul_test(xpu_graph_backend, fn6)

--- a/tests/mlu/test_fuse_matmul.py
+++ b/tests/mlu/test_fuse_matmul.py
@@ -108,12 +108,18 @@ def fn19(inputs, weight, bias):
     return output
 
 
+def fn20(inputs, weight, bias):
+    output = fn3(inputs, weight, bias).reshape(128, 32, 16)
+    output = torch.sigmoid(output)
+    return output.view(-1).reshape(128, 32, 16)
+
+
 def matmul_test(xpu_graph_backend, func):
     if func in [fn0, fn1, fn9]:
         inputs = torch.randn((4096, 768), device=device, dtype=data_type)
         weight = torch.randn((768, 16), device=device, dtype=data_type)
         bias = torch.randn((16), device=device, dtype=data_type)
-    elif func in [fn2, fn3, fn10, fn11, fn12, fn13, fn14, fn15, fn16, fn17]:
+    elif func in [fn2, fn3, fn10, fn11, fn12, fn13, fn14, fn15, fn16, fn17, fn20]:
         inputs = torch.randn((4096, 768), device=device, dtype=data_type)
         weight = torch.randn((16, 768), device=device, dtype=data_type)
         bias = torch.randn((16), device=device, dtype=data_type)
@@ -171,6 +177,7 @@ class TestMatMul:
             fn17,
             fn18,
             fn19,
+            fn20,
         ],
     )
     def test_matmul_patterns(self, caplog, pattern_func):
@@ -183,11 +190,12 @@ class TestMatMul:
         else:
             assert "Pattern.FusedMatMulAct changed graph" in caplog.text
 
+
 if __name__ == "__main__":
     xpu_graph_backend = xpu_graph.mlu_compiler(
         is_training=False, opt_level=OptLevel.level2
     )
-    matmul_test(xpu_graph_backend, fn16)
+    matmul_test(xpu_graph_backend, fn20)
     matmul_test(xpu_graph_backend, fn17)
     matmul_test(xpu_graph_backend, fn18)
     matmul_test(xpu_graph_backend, fn19)

--- a/xpu_graph/passes/patterns/targets/mlu/fuse_combine_matmul.py
+++ b/xpu_graph/passes/patterns/targets/mlu/fuse_combine_matmul.py
@@ -1,0 +1,407 @@
+from typing import Optional, Tuple, Union
+
+import torch
+from torch import nn, fx
+import torch_mlu
+from xpu_graph.utils import logger
+from xpu_graph.config import OptLevel
+from xpu_graph.passes.patterns.pattern import Pattern, PatternGroup
+from ...utils.check_ops import (
+    check_mm_op,
+    check_add_op,
+    check_view,
+    check_act_op,
+    check_trans_op,
+    check_bmm_op,
+    check_addmm_op,
+    check_t_op,
+    # get_shape,
+)
+import operator
+
+TensorShape = Union[torch.Size, Tuple[int, ...]]
+NodeType = fx.Node
+COMBINE_LEN = 4
+
+from typing import Optional, Union
+from torch.fx.node import map_arg
+
+
+def extract_nodes_from_args_kwargs(args, kwargs):
+    """
+    从给定的 args 和 kwargs 中递归提取所有 fx.Node 实例。
+    """
+    nodes = []
+
+    def recurse(item):
+        if isinstance(item, fx.Node):
+            nodes.append(item)
+        elif isinstance(item, (list, tuple)):
+            for elem in item:
+                recurse(elem)
+        elif isinstance(item, dict):
+            for value in item.values():
+                recurse(value)
+        # 其他类型（如 int、float、str 等）不处理
+
+    recurse(args)
+    recurse(kwargs)
+    return nodes
+
+
+def get_ancestors(node):
+    stack = [node]
+    ancestors = []
+    while stack:
+        node = stack.pop()
+        if node in ancestors:
+            continue
+        if node is None:
+            continue
+        if node.op == "placeholder":
+            continue
+        ancestors.append(node)
+        stack += extract_nodes_from_args_kwargs(node.args, node.kwargs)
+    if len(ancestors) > 0:
+        # remove node
+        ancestors = ancestors[1:]
+    return ancestors
+
+
+def get_shape(node: fx.Node):
+    if not hasattr(node, "meta"):
+        return None
+    node_meta = node.meta
+    if "val" not in node_meta:
+        return None
+    val = node_meta["val"]
+    if not hasattr(val, "shape"):
+        return None
+    return val.shape
+
+
+class MMNodeDesc:
+    """
+    NodeDesc class describes a node in torch.fx graph along with its associated information,
+    including input1, input2, bias, and their shapes. It can also store an activation type.
+    """
+
+    def __init__(self) -> None:
+        # The fx.Node itself (typically an mm or addmm operation)
+        self.node: Optional[NodeType] = None
+        self.input1: Optional[NodeType] = None
+        self.input2: Optional[NodeType] = None
+        self.bias: Optional[Union[NodeType, int, float]] = None
+        self.input1_shape: Optional[TensorShape] = None
+        self.input2_shape: Optional[TensorShape] = None
+        self.bias_shape: Optional[TensorShape] = None
+        # Activation function string (default "none")
+        self.act: str = "none"
+        self.input1_ancestors = []
+        self.input2_ancestors = []
+        self.bias_ancestors = []
+
+    def set_node(self, node):
+        self.node = node
+
+    def set_input1(self, input1):
+        self.input1 = input1
+        self.input1_shape = get_shape(input1)
+        self.input1_ancestors = get_ancestors(self.input1)
+
+    def set_input2(self, input2):
+        self.input2 = input2
+        self.input2_shape = get_shape(input2)
+        self.input2_ancestors = get_ancestors(self.input2)
+
+    def set_bias(self, bias):
+        self.bias = bias
+        if bias is not None:
+            self.bias_shape = get_shape(bias)
+            self.bias_ancestors = get_ancestors(self.bias)
+
+    def set_act(self, act: str):
+        self.act = act
+
+
+def get_node_desc(node):
+    intpu1 = None
+    intpu2 = None
+    bias = None
+    act = None
+    check_args = False
+    if node.target == torch.ops.aten.mm.default:
+        input1 = node.args[0]
+        input2 = node.args[1]
+    elif node.target == torch.ops.aten.addmm.default:
+        bias = node.args[0]
+        input1 = node.args[1]
+        input2 = node.args[2]
+    else:
+        # fused_tmo_xxx
+        input1 = node.args[0]
+        input2 = node.args[2]
+        bias = node.args[5]
+        # TODO(JYJ):Remove restrictions
+        trans_b = node.args[4]
+        if trans_b == True:
+            return None
+        if isinstance(bias, (int, float)):
+            return None
+        if "bmm" in node.target:
+            act = node.args[9]
+        else:
+            act = node.args[6]
+
+    if get_shape(input1) == None:
+        return None
+    if get_shape(input2) == None:
+        return None
+    if bias is not None:
+        if get_shape(bias) == None:
+            return None
+
+    mm_desc = MMNodeDesc()
+    mm_desc.set_node(node)
+    mm_desc.set_input1(input1)
+    mm_desc.set_input2(input2)
+    mm_desc.set_bias(bias)
+    mm_desc.set_act(act)
+    # print("mm_desc:", mm_desc.node)
+    # print(mm_desc.input1_ancestors)
+    # print(mm_desc.input2_ancestors)
+    # print(mm_desc.bias_ancestors)
+    return mm_desc
+
+
+def all_same_tensor(tensor_list):
+    if not tensor_list:
+        return True
+    first = tensor_list[0]
+    return all(t is first for t in tensor_list)
+
+
+class FusedCombineBmm(nn.Module):
+    def forward(self, input_list, weight_list, bias_list, act: str):
+        output = None
+        if len(input_list[0].shape) == 3:
+            output = self.forward_bmm(input_list, weight_list, bias_list, act)
+        else:
+            output = self.forward_mm(input_list, weight_list, bias_list, act)
+
+        bias = bias_list[0]
+        if bias is None:
+            bias_batch = None
+        else:
+            bias_list = [
+                bias.unsqueeze(0) if len(bias.shape) == 1 else bias
+                for bias in bias_list
+            ]
+            bias_batch = torch.stack(
+                bias_list, dim=0
+            )  # Stack all biases along a new dimension
+        # Add bias batch if available
+        if bias_batch is not None:
+            output = output + bias_batch
+
+        # Apply activation function if specified
+        if act == "relu":
+            output = torch.relu(output)
+        elif act == "gelu":
+            output = torch.gelu(output)
+        elif act == "silu":
+            output = torch.silu(output)
+        elif act == "sigmoid":
+            output = torch.sigmoid(output)
+
+        return output
+
+    def forward_bmm(self, input_list, weight_list, bias_list, act: str):
+
+        input_batch = torch.stack(input_list, dim=0)
+        weight_batch = torch.stack(weight_list, dim=0)
+        T, B, K, N = weight_batch.shape
+        M = input_list[0].shape[1]
+        output = torch.bmm(
+            input_batch.view(-1, M, K), weight_batch.view(-1, K, N)
+        ).view(T, B, M, N)
+        return output
+
+    def forward_mm(self, input_list, weight_list, bias_list, act: str):
+        if all_same_tensor(input_list):
+            input = input_list[0]
+            input_batch = input.unsqueeze(0).expand(
+                len(input_list), input.shape[0], input.shape[1]
+            )
+        else:
+            input_batch = torch.stack(input_list, dim=0)
+        weight_batch = torch.stack(weight_list, dim=0)
+        B, K, N = weight_batch.shape
+
+        output = torch.bmm(
+            input_batch,
+            weight_batch,  # [B, M, N]
+        )
+        return output
+
+        """
+        # Fallback case: ordinary matmul + bias for each pair
+        else:
+            if len(input_list) == 1:
+                input_list = input_list * len(weight_list)
+            output = [
+                torch.matmul(input, weight) + bias
+                for input, weight, bias in zip(input_list, weight_list, bias_list)
+            ]
+        """
+
+
+def find_last_node_in_list(gm: fx.GraphModule, node_list: list[fx.Node]) -> fx.Node:
+    """
+    Given a list of nodes, find the one that appears last in the graph's topological order.
+    """
+    node_set = set(node_list)  # Faster lookup
+    last_node = None
+
+    for node in gm.graph.nodes:
+        if node in node_set:
+            last_node = node  # Update when we see a matching node
+
+    return last_node
+
+
+def partly_topo_sort(gm: fx.Graph, node: fx.Node):
+    import queue
+
+    que = queue.Queue()
+    que.put(node)
+    while not que.empty():
+        cur = que.get()
+        for user in cur.users:
+            if user < cur:
+                cur.append(user)
+                que.put(user)
+
+
+def replace_node(graph_module, nodes):
+    new_input = [n.input1 for n in nodes]
+    new_weight = [n.input2 for n in nodes]
+    new_bias = [n.bias for n in nodes]
+    act = nodes[0].act
+
+    if len(new_weight) < COMBINE_LEN:
+        return
+    with graph_module.graph.inserting_after(
+        find_last_node_in_list(graph_module, new_input + new_weight + new_bias)
+    ):
+        new_node = graph_module.graph.call_module(
+            "fused_combine_bmm",
+            args=(new_input, new_weight, new_bias, act),
+        )
+    with graph_module.graph.inserting_after(new_node):
+        for idx, n in enumerate(nodes):
+            new_n = graph_module.graph.call_function(
+                operator.getitem, args=(new_node, idx)
+            )
+            n.node.replace_all_uses_with(new_n)
+            partly_topo_sort(graph_module, new_n)
+    graph_module.graph.lint()
+    graph_module.recompile()
+
+
+def has_dependency(a, b):
+    all_a = a.input1_ancestors + a.input2_ancestors + a.bias_ancestors
+    all_b = b.input1_ancestors + b.input2_ancestors + b.bias_ancestors
+    return (
+        a.input1 in all_b
+        or a.input2 in all_b
+        or (a.bias in all_b if a.bias else False)
+        or b.input1 in all_a
+        or b.input2 in all_a
+        or (b.bias in all_a if b.bias else False)
+    )
+
+
+def find_dep(graph_module, nodes):
+    groups = []
+
+    for node in nodes:
+        placed = False
+        for group in groups:
+            if any(has_dependency(node, other) for other in group):
+                continue
+            group.append(node)
+            placed = True
+            break
+        if not placed:
+            groups.append([node])
+
+    return groups
+
+
+def combine_matmul(graph_module, candidates):
+    changed = False
+    group_by_shape = {}
+    for n in candidates:
+        mm_desc = get_node_desc(n)
+        if mm_desc == None:
+            continue
+        key = (
+            mm_desc.input1_shape,
+            mm_desc.input2_shape,
+            mm_desc.bias_shape,
+            mm_desc.act,
+        )
+        if key not in group_by_shape:
+            group_by_shape[key] = []
+        group_by_shape[key].append(mm_desc)
+
+    for key1, group_nodes in group_by_shape.items():
+        group_by_input = find_dep(graph_module, group_nodes)
+        for nodes in group_by_input:
+            if len(nodes) < COMBINE_LEN:
+                continue
+            changed = True
+            replace_node(graph_module, nodes)
+    return changed
+
+
+class FusedCombineMatMul(Pattern):
+    _opt_level = OptLevel.level2
+    _pattern_group = PatternGroup.GROUP1
+
+    def process(self, graph_module: fx.GraphModule) -> bool:
+        changed = False
+
+        graph_module.add_submodule("fused_combine_bmm", FusedCombineBmm())
+        target_module = [
+            "mlu_tmo_fused_bmm_replacement",
+            torch.ops.aten.mm.default,
+            torch.ops.aten.bmm.default,
+            torch.ops.aten.addmm.default,
+            "mlu_tmo_fused_matmul_replacement",
+            "mlu_tmo_fused_matmul_add_replacement",
+            "mlu_tmo_fused_matmul_act_replacement",
+            "mlu_tmo_fused_matmul_add_act_replacement",
+            "mlu_tmo_fused_bmm_add_replacement",
+            "mlu_tmo_fused_bmm_act_replacement",
+            "mlu_tmo_fused_bmm_add_act_replacement",
+        ]
+
+        for module in target_module:
+            candidates = [
+                node
+                for node in graph_module.graph.nodes
+                if (node.op == "call_function" or node.op == "call_module")
+                and node.target == module
+            ]
+            if len(candidates) < COMBINE_LEN:
+                continue
+            changed = changed | combine_matmul(graph_module, candidates)
+            graph_module.graph.lint()
+            graph_module.recompile()
+        if changed:
+            print("after")
+            print(graph_module.graph)
+
+        return changed

--- a/xpu_graph/passes/patterns/targets/mlu/fuse_matmul.py
+++ b/xpu_graph/passes/patterns/targets/mlu/fuse_matmul.py
@@ -34,11 +34,10 @@ class MMParam:
         self.bias1: Optional[Union[NodeType, int, float]] = None
         self.bias2: Optional[Union[NodeType, int, float]] = None
         self.act: str = "none"
-        self.shape_param: Optional[Tuple[int, ...]] = None
         self.node_name: list = []
 
     def set_node(self, node):
-        if len(node.args) != 8:
+        if len(node.args) != 7:
             return False
         self.input = node.args[0]
         self.input_shape = node.args[1]
@@ -50,11 +49,7 @@ class MMParam:
             if not self.set_bias1(node.args[5]):
                 return False
 
-        if node.args[6] is not None:
-            if not self.set_shape_param(node.args[6]):
-                return False
-
-        if not self.set_act(node.args[7]):
+        if not self.set_act(node.args[6]):
             return False
 
         return True
@@ -111,31 +106,6 @@ class MMParam:
             return False
         return True
 
-    def set_shape_param(self, shape_param):
-        weight1_shape_1 = (
-            self.weight1_shape[1]
-            if self.weight1_trans == False
-            else self.weight1_shape[0]
-        )
-        if -1 not in shape_param:
-            t = 1
-            for s in shape_param:
-                t = t * s
-            if t != self.input_shape[0] * weight1_shape_1:
-                logger.warning(
-                    f"MatMul pass: Unsupported view: input_shape: {self.input_shape}, weight_shape: {self.weight1_shape}, weight_trans: {self.weight1_trans},  shape_param: {shape_param}"
-                )
-                return False
-        if len(shape_param) == 2:
-            if (
-                self.input_shape[0] == shape_param[0]
-                and weight1_shape_1 == shape_param[1]
-            ):
-                self.shape_param = None
-                return True
-        self.shape_param = shape_param
-        return True
-
     def set_bias1(self, bias):
         if isinstance(bias, int):
             self.bias1 = bias
@@ -164,16 +134,14 @@ class MMParam:
         return True
 
     def set_act(self, act_str):
-        if act_str in ["gelu", "relu", "silu", "none"]:
+        if act_str in ["gelu", "relu", "silu", "sigmoid", "none"]:
             self.act = act_str
             return True
         return False
 
 
 class FusedMatMulReplacement(nn.Module):
-    def forward(
-        self, inputs, input_shape, weight, weight_shape, trans_b, bias, shape_param, act
-    ):
+    def forward(self, inputs, input_shape, weight, weight_shape, trans_b, bias, act):
         import torch_mlu_ops
 
         # input last dim must be contiguous.
@@ -203,24 +171,26 @@ class FusedMatMulReplacement(nn.Module):
                     False,
                     trans_b=trans_b,
                 )
-                if shape_param:
-                    output = output.view(shape_param)
                 return output
+        #TODO(jyj): waiting for tmo version update
+        tmp_act = act
+        if act == "sigmoid":
+            tmp_act = "none"
         # bias 2d or None
         output = torch_mlu_ops.matmul(
             inputs,
             weight,
             None,
             bias,
-            act,
+            tmp_act,
             1.0,
             0.0 if bias is None else 1.0,
             False,
             False,
             trans_b=trans_b,
         )
-        if shape_param:
-            output = output.view(shape_param)
+        if act == "sigmoid":
+            return torch.sigmoid(output)
         return output
 
 
@@ -251,7 +221,6 @@ def replace_node(graph_module, node, mm_param, func_name):
                 mm_param.weight1_shape,
                 mm_param.weight1_trans,
                 mm_param.bias1,
-                mm_param.shape_param,
                 mm_param.act,
             ),
         )
@@ -266,21 +235,54 @@ def match_mm(graph_module):
         is_match, mm_param = _is_matmul(node)
         if is_match:
             new_node = replace_node(
-                graph_module, node, mm_param, "mlu_tmo_fused_matmul_1_replacement"
+                graph_module, node, mm_param, "mlu_tmo_fused_matmul_replacement"
             )
             changed = True
     return changed
 
 
+def swap_view_between(graph_module, func1, func2):
+    for node in reversed(graph_module.graph.nodes):
+        if not func1(node):
+            continue
+        view_node = node.args[0]
+        if not check_view(view_node):
+            continue
+        mm_node = view_node.args[0]
+        if not func2(mm_node):
+            continue
+        if len(mm_node.users) != 1:
+            continue
+        if len(view_node.users) != 1:
+            continue
+
+        with graph_module.graph.inserting_before(view_node):
+            new_node = graph_module.graph.call_function(
+                node.target,
+                args=(mm_node,),
+                kwargs=node.kwargs,
+            )
+        view_node.args = (new_node,) + view_node.args[1:]
+        node.replace_all_uses_with(view_node)
+        graph_module.graph.erase_node(node)
+
+
 def match_mm_add1(graph_module):
     changed = False
+    # swap view
+    swap_view_between(
+        graph_module,
+        check_add_op,
+        lambda a: a.target != "mlu_tmo_fused_matmul_replacement",
+    )
+
     for node in reversed(graph_module.graph.nodes):
         if not check_add_op(node):
             continue
         mm_node = node.args[0]
         if not isinstance(mm_node, fx.Node):
             continue
-        if mm_node.target != "mlu_tmo_fused_matmul_1_replacement":
+        if mm_node.target != "mlu_tmo_fused_matmul_replacement":
             continue
         if len(mm_node.users) != 1:
             continue
@@ -293,7 +295,7 @@ def match_mm_add1(graph_module):
         if not mm_param.set_bias1(bias):
             continue
         new_node = replace_node(
-            graph_module, node, mm_param, "mlu_tmo_fused_matmul_2_replacement"
+            graph_module, node, mm_param, "mlu_tmo_fused_matmul_add_replacement"
         )
         assert new_node.args[0] == mm_param.input
         graph_module.graph.erase_node(mm_node)
@@ -324,7 +326,7 @@ def match_mm_add2(graph_module):
         is_match, mm_param = _is_addmm(node)
         if is_match:
             new_node = replace_node(
-                graph_module, node, mm_param, "mlu_tmo_fused_matmul_2_replacement"
+                graph_module, node, mm_param, "mlu_tmo_fused_matmul_add_replacement"
             )
             changed = True
     return changed
@@ -332,13 +334,24 @@ def match_mm_add2(graph_module):
 
 def match_mm_act(graph_module):
     changed = False
+    swap_view_between(
+        graph_module,
+        lambda a: check_act_op(a)[0],
+        lambda a: a.target != "mlu_tmo_fused_matmul_replacement",
+    )
+    swap_view_between(
+        graph_module,
+        lambda a: check_act_op(a)[0],
+        lambda a: a.target != "mlu_tmo_fused_matmul_add_replacement",
+    )
+
     for node in reversed(graph_module.graph.nodes):
         is_cat, act_str = check_act_op(node)
         if not is_cat:
             continue
         mm_node = node.args[0]
-        if (mm_node.target != "mlu_tmo_fused_matmul_1_replacement") and (
-            mm_node.target != "mlu_tmo_fused_matmul_2_replacement"
+        if (mm_node.target != "mlu_tmo_fused_matmul_replacement") and (
+            mm_node.target != "mlu_tmo_fused_matmul_add_replacement"
         ):
             continue
         if len(mm_node.users) != 1:
@@ -349,37 +362,14 @@ def match_mm_act(graph_module):
             continue
         if not mm_param.set_act(act_str):
             continue
-        if mm_node.target == "mlu_tmo_fused_matmul_1_replacement":
+        if mm_node.target == "mlu_tmo_fused_matmul_replacement":
             new_node = replace_node(
-                graph_module, node, mm_param, "mlu_tmo_fused_matmul_3_replacement"
+                graph_module, node, mm_param, "mlu_tmo_fused_matmul_act_replacement"
             )
-        elif mm_node.target == "mlu_tmo_fused_matmul_2_replacement":
+        elif mm_node.target == "mlu_tmo_fused_matmul_add_replacement":
             new_node = replace_node(
-                graph_module, node, mm_param, "mlu_tmo_fused_matmul_4_replacement"
+                graph_module, node, mm_param, "mlu_tmo_fused_matmul_add_act_replacement"
             )
-        assert new_node.args[0] == mm_param.input
-        graph_module.graph.erase_node(mm_node)
-        changed = True
-    return changed
-
-
-def match_mm_view(graph_module, target_str):
-    changed = False
-    for node in reversed(graph_module.graph.nodes):
-        if not check_view(node):
-            continue
-        mm_node = node.args[0]
-        if mm_node.target != target_str:
-            continue
-        if len(mm_node.users) != 1:
-            continue
-        mm_param = MMParam()
-        if not mm_param.set_node(mm_node):
-            logger.info(f"MatMul Pass: invalid pattern in match_mm_add: {mm_node.name}")
-            continue
-        if not mm_param.set_shape_param(node.args[1]):
-            continue
-        new_node = replace_node(graph_module, node, mm_param, mm_node.target)
         assert new_node.args[0] == mm_param.input
         graph_module.graph.erase_node(mm_node)
         changed = True
@@ -392,10 +382,9 @@ class FusedMatMul(Pattern):
     def process(self, graph_module: fx.GraphModule) -> bool:
         is_modified = False
         graph_module.add_submodule(
-            "mlu_tmo_fused_matmul_1_replacement", FusedMatMulReplacement()
+            "mlu_tmo_fused_matmul_replacement", FusedMatMulReplacement()
         )
         is_modified |= match_mm(graph_module)
-        is_modified |= match_mm_view(graph_module, "mlu_tmo_fused_matmul_1_replacement")
 
         return is_modified
 
@@ -406,11 +395,10 @@ class FusedMatMulAdd(Pattern):
     def process(self, graph_module: fx.GraphModule) -> bool:
         is_modified = False
         graph_module.add_submodule(
-            "mlu_tmo_fused_matmul_2_replacement", FusedMatMulReplacement()
+            "mlu_tmo_fused_matmul_add_replacement", FusedMatMulReplacement()
         )
         is_modified |= match_mm_add1(graph_module)
         is_modified |= match_mm_add2(graph_module)
-        is_modified |= match_mm_view(graph_module, "mlu_tmo_fused_matmul_2_replacement")
 
         return is_modified
 
@@ -422,14 +410,12 @@ class FusedMatMulAct(Pattern):
         # mm+act
         is_modified = False
         graph_module.add_submodule(
-            "mlu_tmo_fused_matmul_3_replacement", FusedMatMulReplacement()
+            "mlu_tmo_fused_matmul_act_replacement", FusedMatMulReplacement()
         )
         # mm+bias+act
         graph_module.add_submodule(
-            "mlu_tmo_fused_matmul_4_replacement", FusedMatMulReplacement()
+            "mlu_tmo_fused_matmul_add_act_replacement", FusedMatMulReplacement()
         )
         is_modified |= match_mm_act(graph_module)
-        is_modified |= match_mm_view(graph_module, "mlu_tmo_fused_matmul_3_replacement")
-        is_modified |= match_mm_view(graph_module, "mlu_tmo_fused_matmul_4_replacement")
 
         return is_modified

--- a/xpu_graph/passes/patterns/utils/check_ops.py
+++ b/xpu_graph/passes/patterns/utils/check_ops.py
@@ -252,6 +252,8 @@ def check_act_op(
         return True, "gelu"
     if node.target == aten.relu.default:
         return True, "relu"
+    if node.target == aten.sigmoid.default:
+        return True, "sigmoid"
     return False, None
 
 


### PR DESCRIPTION
1. 调整fused_bmm/fused_matmul的view修改顺序。之前：所有fused_matmul后面的view都会被吃进去。现在：add/act前面有view，调换顺序，不在fused_matmul里面进行view转换
2. pattern支持matmul后融合sigmoid，tmo下个版本支持。
3. 更改自定义module name名字，更易读。