### PR TITLE
perf(triton): add libentry before kernel to improve host performance

### DIFF
--- a/xpu_graph/passes/patterns/targets/mlu/fuse_matmul.py
+++ b/xpu_graph/passes/patterns/targets/mlu/fuse_matmul.py
@@ -199,7 +199,7 @@ class FusedMatMulReplacement(nn.Module):
                     act,
                     1.0,
                     0.0,
-                    False,
+                    True,
                     False,
                     trans_b=trans_b,
                 )

--- a/xpu_graph/passes/patterns/targets/mlu/triton_kernel/fused_mul_sum_cat.py
+++ b/xpu_graph/passes/patterns/targets/mlu/triton_kernel/fused_mul_sum_cat.py
@@ -3,6 +3,7 @@ import torch_mlu
 import triton
 import triton.language as tl
 from typing import List
+from . import libentry
 
 @triton.jit
 def single_mul_sum_cat(
@@ -76,6 +77,7 @@ def single_mul_sum_cat(
     )
     tl.store(output_block_ptr, value0, boundary_check=(0,))
 
+@libentry.libentry()
 @triton.jit
 def mlu_triton_mul_sum_cat_kernel(
     mul0,

--- a/xpu_graph/passes/patterns/targets/mlu/triton_kernel/fused_slice.py
+++ b/xpu_graph/passes/patterns/targets/mlu/triton_kernel/fused_slice.py
@@ -5,7 +5,6 @@ import triton.language as tl
 from typing import List
 from . import libentry
 
-
 @libentry.libentry()
 @triton.jit
 def mlu_triton_slice_low_kernel(

--- a/xpu_graph/passes/patterns/targets/mlu/triton_kernel/fused_slice_cat.py
+++ b/xpu_graph/passes/patterns/targets/mlu/triton_kernel/fused_slice_cat.py
@@ -2,8 +2,9 @@ import torch
 import torch_mlu
 import triton
 import triton.language as tl
+from . import libentry
 
-
+@libentry.libentry()
 @triton.jit
 def mlu_triton_slice_cat_kernel(
     data_ptr, output_ptr, indices_ptr, stride, n_elements, BLOCK_SIZE: tl.constexpr

--- a/xpu_graph/passes/patterns/targets/mlu/triton_kernel/fused_slice_sum_cat.py
+++ b/xpu_graph/passes/patterns/targets/mlu/triton_kernel/fused_slice_sum_cat.py
@@ -4,6 +4,7 @@ import torch_mlu
 import triton
 import triton.language as tl
 from typing import List
+from . import libentry
 
 dtype_dict = {
     torch.bfloat16: 1,
@@ -11,19 +12,19 @@ dtype_dict = {
     torch.float32: 3,
 }
 
-
+@libentry.libentry()
 @triton.jit
 def mlu_triton_slice_sum_cat_kernel(
     output_ptr,
     input_ptr,
     indices_ptr,
     input_stride0,
-    input_stride1,
+    input_stride1: tl.constexpr,
     output_stride0,
     total_jobs,
     row,
     col,
-    output_num,
+    output_num: tl.constexpr,
     BLOCK_SIZE_T: tl.constexpr = 32,
     BLOCK_SIZE_I: tl.constexpr = 32,
     BLOCK_SIZE_R: tl.constexpr = 32,
@@ -52,21 +53,15 @@ def mlu_triton_slice_sum_cat_kernel(
         input_offset = input_ptr + offset_id * input_stride0
         output_offset = output_ptr + offset_id * output_stride0
 
-        # Load the slice input using the largest slice input parameter.
-        input_data = tl.load(
-            input_offset + offset_row[:, None] * input_stride1 + offset_col[None, :],
-            mask=mask,
-        )
-        for i in range(output_num):
+        for i in tl.static_range(output_num):
             # slice from input_data on chip
             indices_start = indices[i * 2]
             indices_end = indices[i * 2 + 1]
-            slice_mask = (offset_row < indices_end) & (offset_row > (indices_start - 1))
-            combined_mask = slice_mask[:, None] & mask_col[None, :]
-            slice_value = tl.where(combined_mask, input_data, 0)
-            sum_value = tl.sum(slice_value, axis=0)
+            valid_rows = (offset_row >= indices_start) & (offset_row < indices_end)
+            slice_data = tl.load(input_offset + offset_row[:, None] * input_stride1 + offset_col[None, :],
+                mask=valid_rows[:, None] & mask_col[None, :], other=0)
+            sum_value = tl.sum(slice_data, axis=0)
             tl.store(output_offset + i * col + offset_col, sum_value, mask=mask_col)
-
 
 @torch.library.custom_op(
     "torch_mlu_triton::fuse_slice_sum_cat", mutates_args=(), device_types="mlu"
@@ -94,6 +89,7 @@ def fuse_slice_sum_cat(
     block_size_r = ((end_row + mini_block - 1) // mini_block) * mini_block
     block_size_c = ((col + mini_block - 1) // mini_block) * mini_block
     grid = (processor_count, 1, 1)
+
     mlu_triton_slice_sum_cat_kernel[grid](
         output_tensor,
         input_tensor,
@@ -111,8 +107,8 @@ def fuse_slice_sum_cat(
         block_size_c,
         num_stages=3,
     )
-    return output_tensor
 
+    return output_tensor
 
 @fuse_slice_sum_cat.register_fake
 def fuse_slice_sum_cat_fake(
@@ -128,3 +124,4 @@ def fuse_slice_sum_cat_fake(
         device=input_tensor.device,
     )
     return output_tensor
+

--- a/xpu_graph/passes/patterns/targets/mlu/triton_kernel/fused_slice_where_cat.py
+++ b/xpu_graph/passes/patterns/targets/mlu/triton_kernel/fused_slice_where_cat.py
@@ -3,7 +3,9 @@ import torch
 import torch_mlu
 import triton
 import triton.language as tl
+from . import libentry
 
+@libentry.libentry()
 @triton.jit
 def mlu_triton_slice_where_cat_kernel(
     output_ptr,


### PR DESCRIPTION
1. 在triton算子前面添加libentry，在cudagraph不开启时提升host性能, 
2. tmomatmul的激活设置高性能模式，提升gelu算子的性能，已验证model A精度无问题。model A整网性能提升1.5%
3. 针对model A的规模新增slicesumcat opt kernel，进一步优化性能，kernel提升80%, model A整网性能提升2.5%