### PR TITLE
perf(triton) add mlu device util to speedup triton kernel

### DIFF
--- a/xpu_graph/passes/patterns/targets/mlu/fuse_sum_cat.py
+++ b/xpu_graph/passes/patterns/targets/mlu/fuse_sum_cat.py
@@ -97,16 +97,13 @@ class SliceSumCatOperation(nn.Module):
                 target_tensors.append(sum_tensor)
             return torch.cat(target_tensors, axis=-1)
         else:
-            processor_count = torch.mlu.get_device_properties(
-                torch.mlu.current_device()
-            ).multi_processor_count
             slice_ = []
             for param in slice_param:
                 slice_ += [param[0], param[1]]
             slice_tensor = torch.tensor(slice_, dtype=torch.int32, device=input.device)
             output_num = len(slice_param)
             return fuse_slice_sum_cat(
-                input, slice_tensor, processor_count, output_num, end
+                input, slice_tensor, output_num, end
             )
 
 

--- a/xpu_graph/passes/patterns/targets/mlu/structure_replacements.py
+++ b/xpu_graph/passes/patterns/targets/mlu/structure_replacements.py
@@ -54,7 +54,6 @@ class FuseSliceCatSameInputModule(torch.nn.Module):
             rows,
             len(indices),
             input_tensor.stride(0),
-            16384,  # blocksize
         )
 
 

--- a/xpu_graph/passes/patterns/targets/mlu/triton_kernel/fused_slice.py
+++ b/xpu_graph/passes/patterns/targets/mlu/triton_kernel/fused_slice.py
@@ -5,7 +5,6 @@ import triton.language as tl
 from typing import List
 from . import libentry
 
-
 @libentry.libentry()
 @triton.jit
 def mlu_triton_slice_low_kernel(

--- a/xpu_graph/passes/patterns/targets/mlu/triton_kernel/fused_slice_cat.py
+++ b/xpu_graph/passes/patterns/targets/mlu/triton_kernel/fused_slice_cat.py
@@ -2,11 +2,20 @@ import torch
 import torch_mlu
 import triton
 import triton.language as tl
+from . import libentry
+from .get_mlu_devinfo import get_device_properties
 
 
+@libentry.libentry()
 @triton.jit
 def mlu_triton_slice_cat_kernel(
-    data_ptr, output_ptr, indices_ptr, stride, n_elements, BLOCK_SIZE: tl.constexpr
+    data_ptr,
+    output_ptr,
+    indices_ptr,
+    stride,
+    n_elements,
+    total_jobs,
+    BLOCK_SIZE: tl.constexpr,
 ):
     block_id = tl.program_id(1)
     offset = block_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
@@ -14,13 +23,20 @@ def mlu_triton_slice_cat_kernel(
 
     indices = tl.load(indices_ptr + offset, mask=mask, other=0)
 
-    row_id = tl.program_id(0)
+    program_dim = tl.num_programs(axis=0)
+    program_id = tl.program_id(0)
+    block_jobs = total_jobs // program_dim
+    block_jobs_r = block_jobs
+    if program_id == program_dim - 1:
+        block_jobs_r = total_jobs - block_jobs * (program_dim - 1)
 
-    data_offset = row_id * stride + indices
-    data = tl.load(data_ptr + data_offset, mask=mask, other=0)
+    for i in range(block_jobs_r):
+        row_id = block_jobs * program_id + i
+        data_offset = row_id * stride + indices
+        data = tl.load(data_ptr + data_offset, mask=mask, other=0)
 
-    output_offset = row_id * n_elements + offset
-    tl.store(output_ptr + output_offset, data, mask=mask)
+        output_offset = row_id * n_elements + offset
+        tl.store(output_ptr + output_offset, data, mask=mask)
 
 
 @torch.library.custom_op("torch_mlu_triton::fused_slice_cat", mutates_args=())
@@ -30,25 +46,29 @@ def fused_slice_cat(
     n_rows: int,
     elements: int,
     input_stride: int,
-    block_size: int,
 ) -> torch.Tensor:
+    props = get_device_properties()
+    size_of_dtype = 2
+    if input_tensor.dtype == torch.float32:
+        size_of_dtype = 4
+    # 4 is int32(indices)
+    block_size = min(props.max_nram_size // (size_of_dtype + 4), elements)
     num_blocks = (elements + block_size - 1) // block_size
     output_tensor = torch.empty(
         (n_rows, elements), dtype=input_tensor.dtype, device=input_tensor.device
     )
-    mlu_triton_slice_cat_kernel[(n_rows, num_blocks)](
+    mlu_triton_slice_cat_kernel[(props.total_cores, num_blocks)](
         input_tensor,
         output_tensor,
         indices_tensor,
         input_stride,
         elements,
+        n_rows,
         BLOCK_SIZE=block_size,
     )
     return output_tensor
 
 
 @fused_slice_cat.register_fake
-def fused_slice_cat_fake(
-    input_tensor, indices_tensor, n_rows, elements, input_stride, block_size
-):
+def fused_slice_cat_fake(input_tensor, indices_tensor, n_rows, elements, input_stride):
     return torch.empty(n_rows, elements, device=input_tensor.device)

--- a/xpu_graph/passes/patterns/targets/mlu/triton_kernel/fused_slice_where_cat.py
+++ b/xpu_graph/passes/patterns/targets/mlu/triton_kernel/fused_slice_where_cat.py
@@ -3,7 +3,9 @@ import torch
 import torch_mlu
 import triton
 import triton.language as tl
+from . import libentry
 
+@libentry.libentry()
 @triton.jit
 def mlu_triton_slice_where_cat_kernel(
     output_ptr,

--- a/xpu_graph/passes/patterns/targets/mlu/triton_kernel/get_mlu_devinfo.py
+++ b/xpu_graph/passes/patterns/targets/mlu/triton_kernel/get_mlu_devinfo.py
@@ -1,0 +1,22 @@
+from functools import lru_cache
+from collections import namedtuple
+import torch
+import triton.language as tl
+import triton.backends.mlu.driver as driver
+import copy
+import math
+
+DeviceProperties = namedtuple('DeviceProperties', ['cluster_num', 'cores_per_cluster', 'total_cores', 'max_nram_size'])
+
+@lru_cache(maxsize=None)
+def get_device_properties():
+    _devprob = driver.BangUtils().get_device_properties(torch.mlu.current_device())
+    cluster_num = _devprob.get('cluster_num')
+    cores_per_cluster = _devprob.get('core_num_per_cluster')
+    total_cores = cluster_num * cores_per_cluster
+    max_nram_size = int(_devprob.get("max_nram_size") * 0.8)
+    return DeviceProperties(cluster_num, cores_per_cluster, total_cores, max_nram_size)
+
+#props = get_device_properties()
+#print(f"Cluster Num: {props.cluster_num}, Cores per Cluster: {props.cores_per_cluster}, Total Cores: {props.total_cores}, Max nram size: {props.max_nram_size}")
+


### PR DESCRIPTION
1. 在triton算子前面添加libentry，在cudagraph不开启时提升host性能
2. 增加获取mlu设备信息
3. 根据设备信息更新slice_cat和mul_slice_cat的block_size （mlu上的nramsize因硬件不同而不同）,slice_cat和mul_sum_cat均有提升
4. 更新slice_sum_cat的写法，把where替换成load，效率更高。kernel耗时提升80%
5. 精度报告已放到文档上