### PR TITLE
fix(common): add aten.concat to check_cat_op when pregrad&backward

### DIFF
--- a/xpu_graph/passes/patterns/common/fold_cat.py
+++ b/xpu_graph/passes/patterns/common/fold_cat.py
@@ -1,5 +1,6 @@
 import torch
 import torch.fx as fx
+
 from xpu_graph.fx_utils import FxStage
 from xpu_graph.passes.patterns.pattern import Pattern
 from xpu_graph.passes.patterns.utils.check_ops import check_cat_op
@@ -21,11 +22,7 @@ class FoldCat(Pattern):
 
     def process(self, gm: fx.GraphModule):
         changed = False
-        candidates = [
-            node
-            for node in gm.graph.nodes
-            if node.op == "call_function" and node.target == torch.ops.aten.cat.default
-        ]
+        candidates = [node for node in gm.graph.nodes if check_cat_op(node)[0]]
 
         for cat in candidates:
             inps = cat.args[0]

--- a/xpu_graph/passes/patterns/utils/check_ops.py
+++ b/xpu_graph/passes/patterns/utils/check_ops.py
@@ -200,7 +200,7 @@ def check_softmax_op(node: fx.Node) -> bool:
 
 
 def check_cat_op(node: fx.Node):
-    is_cat = check_op(node, aten.cat.default)
+    is_cat = check_op(node, aten.cat.default) or check_op(node, aten.concat.default)
     if is_cat:
         if len(node.args) == 1:
             return True, 0


### PR DESCRIPTION
fix(common): add aten.concat to check_cat_op when pregrad&backward

## Problem Description
During the pregrad and backward phases, aten.concat operations are not properly handled by the check_cat_op function, causing the training stage to miss fold_cat optimizations. This leads to suboptimal performance during model training.

## Solution
Add aten.concat to the check_cat_op function's scope to ensure concat operations are correctly processed during pregrad and backward phases, enabling proper fold_cat optimizations.

## Testing
x
