### PR TITLE
feat(release): add two triton kernel feature into release notes

### DIFF
--- a/docs/RELEASE_CURRENT.md
+++ b/docs/RELEASE_CURRENT.md
@@ -10,7 +10,7 @@
 - 现在可以通过环境变量`XPUGRAPH_DEPRECATED_AOT_CONFIG_IS_EXPORT`来控制AOTConfig的`is_export`属性，这可以解决部分`immutable functional tensor`的问题，但副作用不明确，注意未来我们将弃用这一环境变量，使用该环境变量前务必明白使用的意义，否则可能会导致一些未知的问题 #311;
 - 现在whl包更名为`byted-xpu-graph`，并在bytedpypi源上发布，注意与旧版本的包名不同 #313;
 - 现在`Target.npu`支持对`torch.ops.npu.npu_quant_matmul`的权重进行`nd2nz`的转化，通过常量折叠完成编译期优化 #239;
--
+- 添加 add+rmsNorm和silu+mlu 两个triton 写的融合算子及 fx pattern
 
 ## 相关模块API的重大变动
 -


### PR DESCRIPTION
添加 add+nms和 silu+mul 两个 triton kernel 及 fx pattern 特性到 release notes

Closes #297 

# New contributor declaration
- [ x] I am not making a trivial change, such as fixing a typo in a comment.

- [ x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ x] I have run `source scripts/install_githooks.sh`.

- Select one of the following.
  - [ x] I have added tests.
    - `/tests/common` for `common` tests
    - `/tests/mlu` for `MLU` tests
    - `/tests/npu` for `NPU` tests
    - `/tests/xpu_ops` for `xpu-ops` tests
  - [ x] This PR does not need a test because `FILL THIS IN`.
