### PR TITLE
ci(.github/workflows): ci test should be based on the release artifact.

### DIFF
--- a/.github/workflows/ci-for-mlu.yml
+++ b/.github/workflows/ci-for-mlu.yml
@@ -52,6 +52,14 @@ jobs:
       options: --privileged=true --ipc=host --pid=host --user root --network host
     steps:
     - uses: actions/checkout@v4
+    - name: Build And Install Wheel Artifact
+      shell: bash
+      # WARNING(liuyuan): This step is goddamn important for us to keep the release artifact available.
+      run: |
+        export HTTP_PROXY=${XPU_GPRAH_PROXY} HTTPS_PROXY=${XPU_GPRAH_PROXY}
+        pip install -e '.[dev]'
+        python3 -m build .
+        pip install dist/*.whl --force-reinstall --no-deps
     - name: Running mlu tests
       shell: bash
       run: |
@@ -59,8 +67,6 @@ jobs:
         export DEV1=$(( $DEV0 + 1 ))
         export MLU_VISIBLE_DEVICES=$DEV0,$DEV1
         echo "MLU_VISIBLE_DEVICES: $MLU_VISIBLE_DEVICES"
-        export HTTP_PROXY=${XPU_GPRAH_PROXY} HTTPS_PROXY=${XPU_GPRAH_PROXY}
-        pip install -e '.[dev]'
         echo "Running MLU tests..."
         python3 -m pytest --cov=xpu_graph tests/common tests/mlu
     - uses: codecov/codecov-action@v5

--- a/.github/workflows/ci-for-npu.yml
+++ b/.github/workflows/ci-for-npu.yml
@@ -57,11 +57,17 @@ jobs:
       options: --privileged=true --ipc=host --pid=host --user root --shm-size=300g -e ASCEND_VISIBLE_DEIVCES=6 -e ASCEND_RT_VISIBLE_DEVICES=6
     steps:
     - uses: actions/checkout@v4
-    - name: Running npu tests
+    - name: Build And Install Wheel Artifact
+      # WARNING(liuyuan): This step is goddamn important for us to keep the release artifact available.
       shell: bash
       run: |
         export HTTP_PROXY=${XPU_GPRAH_PROXY} HTTPS_PROXY=${XPU_GPRAH_PROXY}
         pip install -e '.[dev]'
+        python3 -m build .
+        pip install dist/*.whl --force-reinstall --no-deps
+    - name: Running npu tests
+      shell: bash
+      run: |
         echo "Running npu tests..."
         python3 -m pytest --cov=xpu_graph --ignore=tests/common/test_inference.py tests/common tests/npu
     - uses: codecov/codecov-action@v5

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,5 @@
 include docs/RELEASE.md
 include scripts/build.py
+
+# WARNING(liuyuan): DO NOT delete the following pattern.
+recursive-include xpu_graph *.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "pytest >= 7.0.0",
     "pytest-cov >= 6.0.0",
     "setuptools >= 65",
+    "build >= 1.2.2",
     "expecttest",
 ]
 


### PR DESCRIPTION
Closes #321 