### PR TITLE
chore(ci): fix CI coverage check to exclude non-target backends.

### DIFF
--- a/.github/workflows/ci-for-mlu.yml
+++ b/.github/workflows/ci-for-mlu.yml
@@ -68,7 +68,10 @@ jobs:
         export MLU_VISIBLE_DEVICES=$DEV0,$DEV1
         echo "MLU_VISIBLE_DEVICES: $MLU_VISIBLE_DEVICES"
         echo "Running MLU tests..."
-        python3 -m pytest --cov=xpu_graph tests/common tests/mlu
+        python3 -m pytest \
+        --cov=xpu_graph \
+        --cov-omit='xpu_graph/backends/npu.py,xpu_graph/passes/patterns/targets/npu/*' \
+        tests/common tests/mlu
     - uses: codecov/codecov-action@v5
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-for-npu.yml
+++ b/.github/workflows/ci-for-npu.yml
@@ -69,7 +69,11 @@ jobs:
       shell: bash
       run: |
         echo "Running npu tests..."
-        python3 -m pytest --cov=xpu_graph --ignore=tests/common/test_inference.py tests/common tests/npu
+        python3 -m pytest \
+        --cov=xpu_graph \
+        --cov-omit='xpu_graph/backends/mlu.py,xpu_graph/passes/patterns/targets/mlu/*' \
+        --ignore=tests/common/test_inference.py \
+        tests/common tests/npu
     - uses: codecov/codecov-action@v5
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
When running NPU tests, some backend modules (like MLU) are not covered in the current CI pipeline. These files are now excluded from the coverage check to avoid misleading coverage reports. The same applies when testing other backends.