### PR TITLE
feat(mlu): add cat to stack pattern

### DIFF
--- a/tests/mlu/test_stack_to_cat.py
+++ b/tests/mlu/test_stack_to_cat.py
@@ -1,0 +1,77 @@
+import torch
+import torch_mlu
+
+import xpu_graph
+from xpu_graph import OptLevel
+from xpu_graph.test_utils import is_similar, need_xpu_graph_logs, skip_xpu_graph_cache
+
+device = "mlu:0"
+aten = torch.ops.aten
+import pytest
+
+
+def fn0(input_list):
+    cat_4 = torch.cat(
+        input_list,
+        dim=-1,
+    )
+
+    stack_4 = torch.stack(input_list)
+
+    return (cat_4, stack_4)
+
+
+def fn1(input_list):
+    cat_4 = torch.cat(
+        input_list,
+        dim=0,
+    )
+
+    stack_4 = torch.stack(input_list)
+
+    return (cat_4, stack_4)
+
+
+def stack_test(xpu_graph_backend, func):
+    # for batch in (10, 512, 31):
+    for batch in (31,):
+        input_list = [torch.rand(batch, 86).to(device=device) for i in range(5)]
+        compiled = torch.compile(func, backend=xpu_graph_backend, dynamic=False)
+        res = compiled(input_list)
+        res1 = func(input_list)
+        for i in range(len(res)):
+            if isinstance(res[i], torch.Tensor):
+                assert is_similar(res[i].cpu().float(), res1[i].cpu().float())
+
+
+class TestStackToCat:
+    def setup_class(self):
+        self.xpu_graph_backend = xpu_graph.mlu_compiler(
+            is_training=False,
+            opt_level=OptLevel.level2,
+            debug=False,
+            vendor_compiler_config={"mode": "default", "cpp_wrapper": True},
+        )
+
+    @pytest.mark.parametrize(
+        "pattern_func",
+        [
+            fn0,
+            fn1,
+        ],
+    )
+    def test_slice_patterns(self, caplog, pattern_func):
+        with need_xpu_graph_logs(), skip_xpu_graph_cache(self.xpu_graph_backend):
+            stack_test(self.xpu_graph_backend, pattern_func)
+        assert "Pattern.CatToStack changed graph" in caplog.text
+
+
+if __name__ == "__main__":
+    xpu_graph_backend = xpu_graph.mlu_compiler(
+        is_training=False,
+        opt_level=OptLevel.level2,
+        debug=True,
+        vendor_compiler_config={"mode": "default", "cpp_wrapper": True},
+    )
+    stack_test(xpu_graph_backend, fn0)
+    # stack_test(xpu_graph_backend, fn1)

--- a/xpu_graph/passes/patterns/targets/mlu/stack_to_cat.py
+++ b/xpu_graph/passes/patterns/targets/mlu/stack_to_cat.py
@@ -1,0 +1,78 @@
+from typing import Optional
+
+import torch
+import torch_mlu
+from torch import fx, nn
+
+from xpu_graph.config import OptLevel
+from xpu_graph.passes.patterns.pattern import Pattern
+from xpu_graph.utils import logger
+
+from ...utils.check_ops import check_cat_op, check_stack_op, get_shape
+
+
+def _is_stack_to_cat(
+    node: fx.Node,
+) -> tuple[bool, Optional[fx.Node], Optional[fx.Node], Optional[fx.Node]]:
+    stack_inputs = node.args[0]
+    last_input = stack_inputs[-1]
+    if len(last_input.users) == 1:
+        return False, 0, None
+    input_shape = get_shape(last_input)
+
+    for key, _ in last_input.users.items():
+        is_cat, axis = check_cat_op(key)
+        if not is_cat:
+            continue
+        if key.args[0] == stack_inputs:
+            return True, axis, key
+    return False, 0, None
+
+
+class CatToStack(Pattern):
+    _opt_level = OptLevel.level1
+    """
+    a = stack([a, b, c, d])
+    b = cat([a, b, c, d], axis = -1)
+    ->
+    b = a.view.trans
+    """
+
+    def process(self, graph_module: fx.GraphModule) -> bool:
+        # only support 2d
+        is_modified = False
+        candidates = [
+            node
+            for node in graph_module.graph.nodes
+            if node.op == "call_function" and check_stack_op(node) and len(get_shape(node)) == 3
+        ]
+        for node in candidates:
+            is_change_stack, axis, cat_node = _is_stack_to_cat(node)
+            if not is_change_stack:
+                continue
+            bs, m, n = get_shape(node)
+
+            with graph_module.graph.inserting_after(node):
+                if axis != 0:
+                    transpose_node = graph_module.graph.call_function(
+                        torch.ops.aten.transpose.int,
+                        args=(node, 1, 0),
+                        kwargs={},
+                    )
+                    with graph_module.graph.inserting_after(transpose_node):
+                        reshape_node = graph_module.graph.call_function(
+                            torch.ops.aten.reshape.default,
+                            args=(transpose_node, [m, bs * n]),
+                            kwargs={},
+                        )
+                    cat_node.replace_all_uses_with(reshape_node)
+                else:
+                    reshape_node = graph_module.graph.call_function(
+                        torch.ops.aten.view.default,
+                        args=(node, [-1, n]),
+                        kwargs={},
+                    )
+                    cat_node.replace_all_uses_with(reshape_node)
+            is_modified = True
+
+        return is_modified


### PR DESCRIPTION
<!---
The core XPU_GRAPH is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

For ModelA 7B: replaces 20 * cat -> 20*contiguous_copy, reduce 21 kernel after fusion. 

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `source scripts/install_githooks.sh`.

- Select one of the following.
  - [x] I have added tests.
    - `/tests/common` for `common` tests
    - `/tests/mlu` for `MLU` tests
    - `/tests/npu` for `NPU` tests
    - `/tests/xpu_ops` for `xpu-ops` tests
  - [ ] This PR does not need a test because `FILL THIS IN`.
