### PR TITLE
fix(device_graph_runner): ensure stream sync after graph replay

### DIFF
--- a/src/xpu_graph/device_graph_runner.py
+++ b/src/xpu_graph/device_graph_runner.py
@@ -137,7 +137,8 @@ class GraphRunner(torch.nn.Module, ABC, PolyBackendDispatcher):
 
     def forward(self, *args, **kwargs) -> torch.Tensor:
         assert self._copy_to_param_buffer(*args, **kwargs)
-        self._graph.replay()
+        with self._stream:
+            self._graph.replay()
         self._stream.synchronize()
         return self._output
 

--- a/src/xpu_graph/device_graph_runner.py
+++ b/src/xpu_graph/device_graph_runner.py
@@ -137,9 +137,7 @@ class GraphRunner(torch.nn.Module, ABC, PolyBackendDispatcher):
 
     def forward(self, *args, **kwargs) -> torch.Tensor:
         assert self._copy_to_param_buffer(*args, **kwargs)
-        with self._stream:
-            self._graph.replay()
-        self._stream.synchronize()
+        self._graph.replay()
         return self._output
 
 

--- a/tests/npu/test_npu_graph.py
+++ b/tests/npu/test_npu_graph.py
@@ -1,5 +1,4 @@
 import torch
-
 from xpu_graph.config import Target
 from xpu_graph.device_graph_runner import GraphRunner
 
@@ -23,3 +22,28 @@ class TestNpuGraphRunner:
         device_graph_2.capture(torch.empty_like(input_tensor).uniform_(3, 4), clone_args=True)
 
         assert torch.allclose(device_graph_2(input_tensor), golden)
+
+    def test_npu_graph_runner_stream_sync(self):
+        H = 8192
+        L = 64
+        model = torch.nn.Sequential(*(torch.nn.Linear(H, H) for _ in range(L))).npu()
+        input_tensor = torch.empty(1024, H, device="npu").uniform_(10, 100)
+
+        golden = model(input_tensor)
+        golden = golden + 2.0
+
+        device_graph = GraphRunner[Target.npu](
+            model,
+            lambda input_tensor: input_tensor,
+            lambda input_buffer, input_tensor: (input_buffer.copy_(input_tensor), True),
+        )
+
+        device_graph.capture(torch.empty_like(input_tensor).uniform_(1, 2))
+
+        result = device_graph.forward(input_tensor)
+
+        s = torch.npu.Stream()
+        with torch.npu.stream(s):
+            result = result + 2.0
+
+        assert torch.allclose(result, golden)


### PR DESCRIPTION
<!---
The core XPU_GRAPH is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

Fix issue where forward stream and capture stream are not the same, causing `self._stream.synchronize()` in GraphRunner to fail to properly synchronize the replay stream. Added a corresponding ut to cover this case.

