### PR TITLE
fix(mlu): fix layernorm and batchmatmul

### DIFF
--- a/src/xpu_graph/passes/patterns/targets/mlu/structure_replacements/dense_layer_modules.py
+++ b/src/xpu_graph/passes/patterns/targets/mlu/structure_replacements/dense_layer_modules.py
@@ -76,6 +76,9 @@ class BatchDenseLayerModule(torch.nn.Module):
             inputs = inputs.contiguous()
         if not weight.is_contiguous():
             weight = weight.contiguous()
+        if bias is not None:
+            if not bias.is_contiguous():
+                bias = bias.contiguous()
         b, m, _ = inputs.shape
         n = weight.shape[-1] if not weight_trans else weight.shape[-2]
         if bias is not None and bias.shape == torch.Size([b, m, n]):

--- a/src/xpu_graph/passes/patterns/targets/mlu/structure_replacements/dense_layer_modules.py
+++ b/src/xpu_graph/passes/patterns/targets/mlu/structure_replacements/dense_layer_modules.py
@@ -17,7 +17,7 @@ class DenseLayerModule(torch.nn.Module):
 
         m = inputs.shape[0]
         n = weight.shape[-1] if not weight_trans else weight.shape[-2]
-        if bias != None:
+        if bias is not None:
             bias_shape = bias.shape
             if len(bias_shape) == 2 and bias_shape[0] == 1:
                 bias = bias.view(-1)

--- a/src/xpu_graph/passes/patterns/targets/mlu/structure_replacements/norm_modules.py
+++ b/src/xpu_graph/passes/patterns/targets/mlu/structure_replacements/norm_modules.py
@@ -14,8 +14,8 @@ class LayerNormModule(torch.nn.Module):
     def forward(self, inputs, weights, bias, epsilon):
         import torch.nn.functional as F
 
-        if weights is None and weights.dtype != inputs.dtype:
+        if weights is not None and weights.dtype != inputs.dtype:
             weights = weights.to(inputs.dtype)
-        if bias is None and bias.dtype != inputs.dtype:
+        if bias is not None and bias.dtype != inputs.dtype:
             bias = bias.to(inputs.dtype)
         return F.layer_norm(inputs, inputs.shape[-1:], weights, bias, epsilon)


### PR DESCRIPTION
1. tmo.batchmatmul 如果走的是cnnl.bmm后融合bias+act，不支持带stride。网络中遇到了bias非contiguous的情况
2. 更正layernorm的判断
